### PR TITLE
fix: build failure with gcc 10

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalCharacterDecoder.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalCharacterDecoder.cpp
@@ -22,6 +22,9 @@
 // Own
 #include "TerminalCharacterDecoder.h"
 
+// std
+#include <cwctype>
+
 // Qt
 #include <QTextStream>
 


### PR DESCRIPTION
Fixes the following build failure:

```
/build/deepin-terminal/src/deepin-terminal-reborn-5.2.1/terminalwidget/lib/TerminalCharacterDecoder.cpp: In member function ‘virtual void Konsole::HTMLDecoder::decodeLine(const Konsole::Character*, int, Konsole::LineProperty)’:
/build/deepin-terminal/src/deepin-terminal-reborn-5.2.1/terminalwidget/lib/TerminalCharacterDecoder.cpp:205:18: error: ‘iswspace’ is not a member of ‘std’; did you mean ‘isspace’?
  205 |         if (std::iswspace(ch))
      |                  ^~~~~~~~
      |                  isspace
```