### PR TITLE
fix: compatibility with new Qt

### DIFF
--- a/3rdparty/terminalwidget/CMakeLists.txt
+++ b/3rdparty/terminalwidget/CMakeLists.txt
@@ -50,6 +50,8 @@ include(LXQtTranslateTs)
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 include(LXQtCreatePkgConfigFile)
 
+remove_definitions(-DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII)
+
 if(APPLE)
     if(CMAKE_VERSION VERSION_GREATER 3.9)
         cmake_policy(SET CMP0068 NEW)


### PR DESCRIPTION
Qt now defines these variables but our codebase relies on it a lot.
Remove this definition to make it buildable.