### PR TITLE
correct the shift+insert behavior to paste selection

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -1334,7 +1334,7 @@ void MainWindow::initShortcuts()
         qDebug() << "built in paste shortcut is activated!" << QKEYSEQUENCE_PASTE_BUILTIN;
         TermWidgetPage *page = currentPage();
         if (page) {
-            page->pasteClipboard();
+            page->pasteSelection();
         }
     });
 

--- a/src/views/termwidgetpage.cpp
+++ b/src/views/termwidgetpage.cpp
@@ -612,6 +612,20 @@ void TermWidgetPage::pasteClipboard()
 }
 
 /*******************************************************************************
+ 1. @函数: void TermWidgetPage::pasteSelection()
+ 2. @作者:     chenzhiwei
+ 3. @日期:     2020-12-20
+ 4. @说明: 使用 Shift+Insert 粘贴时粘贴选中的文本内容
+*******************************************************************************/
+void TermWidgetPage::pasteSelection()
+{
+    TermWidget *term = currentTerminal();
+    if (term) {
+        term->pasteSelection();
+    }
+}
+
+/*******************************************************************************
  1. @函数:    toggleShowSearchBar
  2. @作者:    ut000439 wangpeili
  3. @日期:    2020-08-12

--- a/src/views/termwidgetpage.h
+++ b/src/views/termwidgetpage.h
@@ -79,6 +79,7 @@ public:
 
     void copyClipboard();
     void pasteClipboard();
+    void pasteSelection();
     void toggleShowSearchBar();
 
     void zoomInCurrentTierminal();


### PR DESCRIPTION
The `shift+insert` behavior in other popular terminals is **paste selection**, so I submit PR to make sure deepin-terminal has same behavior as others.

This will help users easily migrate from another terminal to deepin-terminal.