### PR TITLE
fix: implicit QString conversion error

### DIFF
--- a/3rdparty/terminalwidget/lib/Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Emulation.cpp
@@ -301,9 +301,9 @@ void Emulation::receiveData(const char *text, int length, bool isCommandExec)
      * U+10FFFF
      * https://unicodebook.readthedocs.io/unicode_encodings.html#surrogates
      */
-    QString utf16Text = "";
+    QString utf16Text = QString::fromUtf8("");
 
-    if (QString(_codec->name()).toUpper().startsWith("GB") && !isCommandExec) {
+    if (QString::fromUtf8(_codec->name()).toUpper().startsWith(QString::fromUtf8("GB")) && !isCommandExec) {
         if (_decoder != nullptr) {
             delete _decoder;
         }
@@ -327,10 +327,10 @@ void Emulation::receiveData(const char *text, int length, bool isCommandExec)
 
     //fix bug 67102 打开超长名称的文件夹，终端界面光标位置不在最后一位
     //bash 提示符很长的情况下，会有较大概率以五个\b字符结尾，导致光标错位
-    if (utf16Text.startsWith("\u001B]0;") && utf16Text.endsWith("\b\b\b\b\b")) {
+    if (utf16Text.startsWith(QString::fromUtf8("\u001B]0;")) && utf16Text.endsWith(QString::fromUtf8("\b\b\b\b\b"))) {
         Session *currSession = SessionManager::instance()->idToSession(_sessionId);
         if (currSession && (QStringLiteral("bash") == currSession->foregroundProcessName())) {
-            utf16Text.replace("\b\b\b\b\b", "");
+            utf16Text.replace(QString::fromUtf8("\b\b\b\b\b"), QString::fromUtf8(""));
         }
     }
 

--- a/3rdparty/terminalwidget/lib/Filter.cpp
+++ b/3rdparty/terminalwidget/lib/Filter.cpp
@@ -139,7 +139,7 @@ TerminalImageFilterChain::~TerminalImageFilterChain()
 bool isContainOtherPromptEnd(QString promptLine, QString currPromptEnd)
 {
     //四不同类型的提示符结尾字符
-    QString promptEnds = QString("$#%>");
+    QString promptEnds = QString::fromUtf8("$#%>");
     promptEnds.remove(currPromptEnd);
 
     for (int i=0; i<promptEnds.length(); i++)
@@ -178,7 +178,7 @@ void TerminalImageFilterChain::setImage(const Character *const image, int lines,
     QTextStream lineStream(_buffer);
     decoder.begin(&lineStream);
 
-    QString lastLine = "";
+    QString lastLine = QString::fromUtf8("");
     for (int i = 0 ; i < lines ; i++) {
         _linePositions->append(_buffer->length());
         decoder.decodeLine(image + i * columns, columns, LINE_DEFAULT);
@@ -208,7 +208,7 @@ void TerminalImageFilterChain::setImage(const Character *const image, int lines,
     if (lastLine.length() > 0) {
         //优化了截取并保存当前shell提示符的判断，暂时没有考虑PS1被修改的情况（若考虑的话实现起来太复杂）
         //目前针对sh/bash/csh/tcsh/ksh/zsh这几种类型的shell做了处理
-        QString promptEnds = QString("$#%>");
+        QString promptEnds = QString::fromUtf8("$#%>");
         for (int i=0; i<promptEnds.length(); i++) {
             QString promptEnd = promptEnds.at(i);
 
@@ -223,15 +223,15 @@ void TerminalImageFilterChain::setImage(const Character *const image, int lines,
 
     QString strShellPrompt = SessionManager::instance()->getCurrShellPrompt(_sessionId);
 
-    bool isRootUser = strShellPrompt.endsWith("#");
+    bool isRootUser = strShellPrompt.endsWith(QString::fromUtf8("#"));
 
     QString strCurrBuffer = (*_buffer).trimmed();
     if (strCurrBuffer.length() > 0) {
         //获取并保存当前正在输入的命令
         if (isRootUser) {
             QString strCommand = strCurrBuffer.split(strShellPrompt).last();
-            if (!strCommand.contains("sudo ")) {
-                strCommand = QString("sudo %1").arg(strCommand);
+            if (!strCommand.contains(QString::fromUtf8("sudo "))) {
+                strCommand = QString::fromUtf8("sudo %1").arg(strCommand);
             }
             SessionManager::instance()->saveCurrShellCommand(_sessionId, strCommand);
         } else {

--- a/3rdparty/terminalwidget/lib/HistorySearch.cpp
+++ b/3rdparty/terminalwidget/lib/HistorySearch.cpp
@@ -278,11 +278,11 @@ bool HistorySearch::search(int startColumn, int startLine, int endColumn, int en
               存在特殊情况:一个完整的物理行显示在终端被分成多个逻辑行
             */
             //中文字符正则表达式
-            QRegExp regEx("[\u4E00-\u9FA5，《。》、？；：【】～！￥（）]+");
+            QRegExp regEx(QString::fromUtf8("[\u4E00-\u9FA5，《。》、？；：【】～！￥（）]+"));
 
             //未匹配的串-物理行开始和结束位置
             int loseEnd = matchStart;
-            int loseStart = string.lastIndexOf('\n', loseEnd) + 1;
+            int loseStart = string.lastIndexOf(QLatin1Char('\n'), loseEnd) + 1;
             //qDebug() << "loseStart" << loseStart << "loseEnd" << loseEnd ;
 
 //            if (loseStart < 0 || loseStart > loseEnd) {

--- a/3rdparty/terminalwidget/lib/Pty.cpp
+++ b/3rdparty/terminalwidget/lib/Pty.cpp
@@ -282,7 +282,7 @@ Pty::~Pty()
 
 bool Pty::isTerminalRemoved()
 {
-    QFile terminalExecFile("/usr/bin/deepin-terminal");
+    QFile terminalExecFile(QLatin1String("/usr/bin/deepin-terminal"));
     if (terminalExecFile.exists()) {
         return false;
     }
@@ -307,13 +307,13 @@ bool isPatternAcceptable(QString strCommand, QString strPattern)
 //判断当前命令是否是要删除终端
 bool Pty::bWillRemoveTerminal(QString strCommand)
 {
-    QString packageName = "deepin-terminal";
+    QString packageName = QLatin1String("deepin-terminal");
 
     QStringList strCommandList;
     strCommandList.append(strCommand);
 
-    if (strCommand.contains("&&")) {
-        QStringList cmdList = strCommand.split("&&");
+    if (strCommand.contains(QLatin1String("&&"))) {
+        QStringList cmdList = strCommand.split(QLatin1String("&&"));
         for (int i = 0; i < cmdList.size(); i++) {
             QString currCmd = cmdList.at(i).trimmed();
             if (currCmd.length() > 0 && currCmd.contains(packageName)) {
@@ -322,8 +322,8 @@ bool Pty::bWillRemoveTerminal(QString strCommand)
         }
     }
 
-    if (strCommand.contains(";")) {
-        QStringList cmdList = strCommand.split(";");
+    if (strCommand.contains(QLatin1String(";"))) {
+        QStringList cmdList = strCommand.split(QLatin1String(";"));
         for (int i = 0; i < cmdList.size(); i++) {
             QString currCmd = cmdList.at(i).trimmed();
             if (currCmd.length() > 0 && currCmd.contains(packageName)) {
@@ -341,23 +341,23 @@ bool Pty::bWillRemoveTerminal(QString strCommand)
         QString strCurrCommand = strCommandList.at(i);
         for (int j = 0; j < packageNameList.size(); j++) {
             QString packageName = packageNameList.at(j);
-            QString removePattern = QString("sudo\\s+apt-get\\s+remove\\s+%1").arg(packageName);
+            QString removePattern = QString::fromUtf8("sudo\\s+apt-get\\s+remove\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt\\s+remove\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt\\s+remove\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
             /******** Modify by nt001000 renfeixiang 2020-05-27:修改 放到bWillPurgeTerminal函数中 Begin***************/
 //            removePattern = QString("sudo\\s+dpkg\\s+-P\\s+%1").arg(packageName);
 //            acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
             /******** Modify by nt001000 renfeixiang 2020-05-27:修改 放到bWillPurgeTerminal函数中 End***************/
 
-            removePattern = QString("sudo\\s+dpkg\\s+-r\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+dpkg\\s+-r\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+rm\\s+.+\\s+/usr/bin/deepin-terminal");
+            removePattern = QString::fromUtf8("sudo\\s+rm\\s+.+\\s+/usr/bin/deepin-terminal");
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+rm\\s+/usr/bin/deepin-terminal");
+            removePattern = QString::fromUtf8("sudo\\s+rm\\s+/usr/bin/deepin-terminal");
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
         }
     }
@@ -368,13 +368,13 @@ bool Pty::bWillRemoveTerminal(QString strCommand)
 /******** Add by nt001000 renfeixiang 2020-05-27:增加 Purge卸载命令的判断，显示不同的卸载提示框 Begin***************/
 bool Pty::bWillPurgeTerminal(QString strCommand)
 {
-    QString packageName = "deepin-terminal";
+    QString packageName = QLatin1String("deepin-terminal");
 
     QStringList strCommandList;
     strCommandList.append(strCommand);
 
-    if (strCommand.contains("&&")) {
-        QStringList cmdList = strCommand.split("&&");
+    if (strCommand.contains(QLatin1String("&&"))) {
+        QStringList cmdList = strCommand.split(QLatin1String("&&"));
         for (int i = 0; i < cmdList.size(); i++) {
             QString currCmd = cmdList.at(i).trimmed();
             if (currCmd.length() > 0 && currCmd.contains(packageName)) {
@@ -383,8 +383,8 @@ bool Pty::bWillPurgeTerminal(QString strCommand)
         }
     }
 
-    if (strCommand.contains(";")) {
-        QStringList cmdList = strCommand.split(";");
+    if (strCommand.contains(QLatin1String(";"))) {
+        QStringList cmdList = strCommand.split(QLatin1String(";"));
         for (int i = 0; i < cmdList.size(); i++) {
             QString currCmd = cmdList.at(i).trimmed();
             if (currCmd.length() > 0 && currCmd.contains(packageName)) {
@@ -402,31 +402,31 @@ bool Pty::bWillPurgeTerminal(QString strCommand)
         QString strCurrCommand = strCommandList.at(i);
         for (int j = 0; j < packageNameList.size(); j++) {
             QString packageName = packageNameList.at(j);
-            QString removePattern = QString("sudo\\s+apt-get\\s+purge\\s+%1").arg(packageName);
+            QString removePattern = QString::fromUtf8("sudo\\s+apt-get\\s+purge\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt-get\\s+purge\\s+-y\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt-get\\s+purge\\s+-y\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt-get\\s+remove\\s+--purge\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt-get\\s+remove\\s+--purge\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt-get\\s+--purge\\s+remove\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt-get\\s+--purge\\s+remove\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt\\s+purge\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt\\s+purge\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt\\s+purge\\s+-y\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt\\s+purge\\s+-y\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt\\s+remove\\s+--purge\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt\\s+remove\\s+--purge\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+apt\\s+--purge\\s+remove\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+apt\\s+--purge\\s+remove\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
 
-            removePattern = QString("sudo\\s+dpkg\\s+-P\\s+%1").arg(packageName);
+            removePattern = QString::fromUtf8("sudo\\s+dpkg\\s+-P\\s+%1").arg(packageName);
             acceptableList << isPatternAcceptable(strCurrCommand, removePattern);
         }
     }
@@ -446,7 +446,7 @@ void Pty::sendData(const char *data, int length, const QTextCodec *codec)
     //判断是否是点了自定义命令面板列表项触发的命令
     bool isCustomCommand = false;
     QString currCommand = QString::fromLatin1(data);
-    if (currCommand.length() > 0 && currCommand.endsWith('\n')) {
+    if (currCommand.length() > 0 && currCommand.endsWith(QLatin1Char('\n'))) {
         isCustomCommand = true;
     }
 
@@ -462,7 +462,7 @@ void Pty::sendData(const char *data, int length, const QTextCodec *codec)
 
         //检测到当前命令是代码中通过sendText发给终端的(而不是用户手动输入的命令)
         bool isSendByRemoteManage = this->property("isSendByRemoteManage").toBool();
-        if (isSendByRemoteManage && strCurrCommand.startsWith("expect -f")) {
+        if (isSendByRemoteManage && strCurrCommand.startsWith(QLatin1String("expect -f"))) {
             _bNeedBlockCommand = true;
             //立即修改回false，防止误认其他命令
             this->setProperty("isSendByRemoteManage", QVariant(false));
@@ -473,9 +473,9 @@ void Pty::sendData(const char *data, int length, const QTextCodec *codec)
         bool bRemoveTerminal =  bWillRemoveTerminal(strCurrCommand);
 
         if (!isTerminalRemoved() && (bPurgeTerminal || bRemoveTerminal)) {
-            QString strname = "remove";
+            QString strname = QLatin1String("remove");
             if (bPurgeTerminal) {
-                strname = "purge";
+                strname = QLatin1String("purge");
             }
             QMetaObject::invokeMethod(this, "ptyUninstallTerminal", Qt::AutoConnection, Q_RETURN_ARG(bool, _bUninstall), Q_ARG(QString, strname));
             /******** Modify by nt001000 renfeixiang 2020-05-27:修改 根据remove和purge卸载命令，发送信号不同参数值 End***************/
@@ -501,7 +501,7 @@ void Pty::sendData(const char *data, int length, const QTextCodec *codec)
     }
 
     //为GBK/GB2312/GB18030编码，且不是输入命令执行的情况（没有按回车）
-    if (QString(codec->name()).toUpper().startsWith("GB") && !_isCommandExec) {
+    if (QString::fromUtf8(codec->name()).toUpper().startsWith(QLatin1String("GB")) && !_isCommandExec) {
         QTextCodec *utf8Codec = QTextCodec::codecForName("UTF-8");
         QString unicodeData = codec->toUnicode(data);
         QByteArray unicode = utf8Codec->fromUnicode(unicodeData);
@@ -524,19 +524,19 @@ void Pty::dataReceived()
 {
     QByteArray data = pty()->readAll();
 
-    QString recvData = QString(data);
+    QString recvData = QString::fromUtf8(data);
 
     if (_bNeedBlockCommand) {
         QString judgeData = recvData;
         if (recvData.length() > 1) {
-            judgeData = recvData.replace("\r", "");
-            judgeData = judgeData.replace("\n", "");
+            judgeData = recvData.replace(QLatin1String("\r"), QLatin1String(""));
+            judgeData = judgeData.replace(QLatin1String("\n"), QLatin1String(""));
         }
 
         //使用zsh的时候，发送过来的字符会残留一个字母"e"，需要特殊处理下
-        if (_program.endsWith("/zsh")
+        if (_program.endsWith(QLatin1String("/zsh"))
                 && 1 == judgeData.length()
-                && judgeData.startsWith("e")
+                && judgeData.startsWith(QLatin1String("e"))
                 && -1 == _receiveDataIndex) {
             _receiveDataIndex = 0;
             return;
@@ -544,27 +544,27 @@ void Pty::dataReceived()
 
         //不显示远程登录时候的敏感信息(主要是expect -f命令跟随的明文密码)
         //同时考虑了zsh的情况
-        if (judgeData.startsWith("expect -f")
-                || judgeData.startsWith("\bexpect")
-                || judgeData.startsWith("\be")
-                || judgeData.startsWith("e\bexpect")
-                || judgeData.startsWith("e\be")) {
+        if (judgeData.startsWith(QLatin1String("expect -f"))
+                || judgeData.startsWith(QString::fromUtf8("\bexpect"))
+                || judgeData.startsWith(QString::fromUtf8("\be"))
+                || judgeData.startsWith(QString::fromUtf8("e\bexpect"))
+                || judgeData.startsWith(QString::fromUtf8("e\be"))) {
             _receiveDataIndex = 1;
             return;
         }
 
         if (_receiveDataIndex >= 1) {
-            if (judgeData.contains("Press")) {
+            if (judgeData.contains(QLatin1String("Press"))) {
                 //这里需要置回false，否则后面其他命令也会被拦截
                 _bNeedBlockCommand = false;
 
                 _receiveDataIndex = -1;
-                int pressStringIndex = recvData.indexOf("Press");
+                int pressStringIndex = recvData.indexOf(QLatin1String("Press"));
                 if (pressStringIndex > 0) {
                     recvData = recvData.mid(pressStringIndex);
                 }
-                QString helpData = recvData.replace("\n", "");
-                recvData = "\r\n" + helpData + "\r\n";
+                QString helpData = recvData.replace(QLatin1String("\n"), QLatin1String(""));
+                recvData = QLatin1String("\r\n") + helpData + QLatin1String("\r\n");
                 data = recvData.toUtf8();
                 emit receivedData(data.constData(), data.count(), _textCodec);
             }
@@ -577,21 +577,21 @@ void Pty::dataReceived()
 
     /******** Modify by m000714 daizhengwen 2020-04-30: 处理上传下载时乱码显示命令不执行****************/
     // 乱码提示信息不显示
-    if (recvData.contains("bash: $'\\212")
-            || recvData.contains("bash: **0800000000022d：")
-            || recvData.contains("**^XB0800000000022d")
-            || recvData.startsWith("**\u0018B0800000000022d\r\u008A")) {
+    if (recvData.contains(QString::fromUtf8("bash: $'\\212"))
+            || recvData.contains(QString::fromUtf8("bash: **0800000000022d："))
+            || recvData.contains(QString::fromUtf8("**^XB0800000000022d"))
+            || recvData.startsWith(QString::fromUtf8("**\u0018B0800000000022d\r\u008A"))) {
         return;
     }
 
     // "\u008A"这个乱码不替换调会导致显示时有\b的效果导致命令错乱bug#23741
-    if (recvData.contains("\u008A")) {
-        recvData.replace("\u008A", "\b \b #");
+    if (recvData.contains(QString::fromUtf8("\u008A"))) {
+        recvData.replace(QString::fromUtf8("\u008A"), QString::fromUtf8("\b \b #"));
         data = recvData.toUtf8();
     }
 
-    if (recvData == "rz waiting to receive.") {
-        recvData += "\r\n";
+    if (recvData == QLatin1String("rz waiting to receive.")) {
+        recvData += QLatin1String("\r\n");
         data = recvData.toUtf8();
     }
     /********************* Modify by m000714 daizhengwen End ************************/

--- a/3rdparty/terminalwidget/lib/Session.cpp
+++ b/3rdparty/terminalwidget/lib/Session.cpp
@@ -396,7 +396,7 @@ void Session::run()
 
     if (result < 0) {
         //qDebug() << "CRASHED! result: " << result<<arguments;
-        QString infoText = QString("There was an error creating the child process for this terminal. \n"
+        QString infoText = QString::fromUtf8("There was an error creating the child process for this terminal. \n"
                  "Failed to execute child process \"%1\"(No such file or directory)!").arg(exec);
         sendText(infoText);
         _userTitle = QString::fromLatin1("Session crashed");
@@ -549,7 +549,7 @@ void Session::monitorTimerDone()
 void Session::activityStateSet(int state)
 {
     if (state==NOTIFYBELL) {
-        emit bellRequest(QString("Bell in session '%1'").arg(_nameTitle));
+        emit bellRequest(QString::fromUtf8("Bell in session '%1'").arg(_nameTitle));
     } else if (state==NOTIFYACTIVITY) {
         if (_monitorSilence) {
             _monitorTimer->start(_silenceSeconds*1000);
@@ -729,7 +729,7 @@ void Session::done(int exitStatus)
         if (exitStatus == -1){
             infoText.sprintf("There was an error creating the child process for this terminal. \n"
                      "Failed to execute child process \"%s\"(No such file or directory)!", _program.toUtf8().data());
-            message = "Session crashed.";
+            message = QLatin1String("Session crashed.");
         }
         else {
             infoText.sprintf("The child process exited normally with status %d.", exitStatus);

--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -493,7 +493,7 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
   /******** Modify by ut000439 wangpeili 2020-06-24: 适应窗口特效圆角 ****************/
   //qDebug()<<"_scrollBar->width()"<<_scrollBar->width();
   // 设置15px宽度＝6?
-  _scrollBar->setStyleSheet("margin: 0px 0 15px 0;width: 15");
+  _scrollBar->setStyleSheet(QLatin1String("margin: 0px 0 15px 0;width: 15"));
   //qDebug()<<"_scrollBar->width()"<<_scrollBar->width();
   /********************* Modify by n014361 wangpeili End ************************/
 
@@ -3534,8 +3534,8 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
   }
 
   /***add begin by ut001121 zhangmeng 20201030 for SP4.1 拖拽文件到工作区文件路径加引号***/
-  dropText.insert(0, '\'');
-  dropText.append('\'');
+  dropText.insert(0, QLatin1Char('\''));
+  dropText.append(QLatin1Char('\''));
   /***add end ut001121***/
 
     emit sendStringToEmu(dropText.toLocal8Bit().constData());

--- a/3rdparty/terminalwidget/lib/qtermwidget.cpp
+++ b/3rdparty/terminalwidget/lib/qtermwidget.cpp
@@ -641,7 +641,7 @@ void QTermWidget::setColorScheme(const QString &origName, bool needReloadTheme)
             cs = ColorSchemeManager::instance()->defaultColorScheme();
         }
     } else {
-        if (name == "customTheme" && needReloadTheme) {
+        if (name == QLatin1String("customTheme") && needReloadTheme) {
             ColorSchemeManager::instance()->realodColorScheme(origName);
         }
         cs = ColorSchemeManager::instance()->findColorScheme(name);


### PR DESCRIPTION
"const char*" to "QString" conversion is private in newer Qt versions by default, "char" to "QChar" likewise.
Either simply disable macros QT_NO_CAST_FROM_ASCII and QT_NO_CAST_TO_ASCII, or wrap those string literals with functions like QString:fromUtf8(). This commit chooses the latter.

Log:  fix implicit QString conversion error

linuxdeepin/developer-center#2805 

