### PR TITLE
Add option to disable ctrl+<mouse-wheel> zooming

### DIFF
--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -340,6 +340,12 @@
                             "type": "checkbox",
                             "text": "Scroll on output",
                             "default": true
+                        },
+                        {
+                            "key": "zoom_on_ctrl_scrollwheel",
+                            "type": "checkbox",
+                            "text": "Allow Ctrl+scrollwheel to zoom text size",
+                            "default": true
                         }
                     ]
                 },

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -369,6 +369,11 @@ bool Settings::OutputtingScroll()
     return settings->option("advanced.scroll.scroll_on_output")->value().toBool();
 }
 
+bool Settings::ScrollWheelZoom()
+{
+    return settings->option("advanced.scroll.zoom_on_ctrl_scrollwheel")->value().toBool();
+}
+
 /*******************************************************************************
  1. @函数:    reload
  2. @作者:    ut001121 zhangmeng

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -118,6 +118,12 @@ public:
      * @return
      */
     bool OutputtingScroll();
+    /**
+     * @brief 设置界面获取是否允许Ctrl+滚轮扩缩字体
+     * @author chenzhiwei
+     * @return
+     */
+    bool ScrollWheelZoom();
 //    void reload();
     /**
      * @brief 标签标题

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -1155,7 +1155,7 @@ inline void TermWidget::onTouchPadSignal(QString name, QString direction, int fi
     qDebug() << __FUNCTION__;
     qDebug() << name << direction << fingers;
     // 当前窗口被激活,且有焦点
-    if (isActiveWindow() && hasFocus()) {
+    if (isActiveWindow() && hasFocus() && Settings::instance()->ScrollWheelZoom()) {
         if (name == "pinch" && fingers == 2) {
             if (direction == "in") {
                 // 捏合 in是手指捏合的方向 向内缩小
@@ -1190,7 +1190,7 @@ void TermWidget::onShellMessage(QString currentShell, bool isSuccess)
 void TermWidget::wheelEvent(QWheelEvent *event)
 {
     // 当前窗口被激活,且有焦点
-    if (isActiveWindow() && hasFocus()) {
+    if (isActiveWindow() && hasFocus() && Settings::instance()->ScrollWheelZoom()) {
         if (Qt::ControlModifier == event->modifiers()) {
             int directionY = event->angleDelta().y();
             if (directionY < 0) {


### PR DESCRIPTION
Implements: linuxdeepin/developer-center#2810 

This is a really very useful feature when using laptop keyboard and touchpad, avoiding accidentally zoom in/out the font with ctrl + two fingers gesture.

Konsole added this option in year 2012: https://github.com/KDE/konsole/commit/417af269e556cba6330a736b0b3089a053bff07f

Terminator also added this option: https://github.com/gnome-terminator/terminator/pull/46