### PR TITLE
fix: Remove unused variable

### DIFF
--- a/3rdparty/terminalwidget/lib/BlockArray.cpp
+++ b/3rdparty/terminalwidget/lib/BlockArray.cpp
@@ -154,7 +154,7 @@ const Block * BlockArray::at(size_t i)
 
     if (block == (Block *)-1) {
         perror("mmap");
-        realloc(block,0);
+        block = realloc(block,0);
         block = nullptr;
         return nullptr;
     }

--- a/3rdparty/terminalwidget/lib/BlockArray.cpp
+++ b/3rdparty/terminalwidget/lib/BlockArray.cpp
@@ -154,6 +154,8 @@ const Block * BlockArray::at(size_t i)
 
     if (block == (Block *)-1) {
         perror("mmap");
+        realloc(block,0);
+        block = nullptr;
         return nullptr;
     }
 

--- a/src/main/service.cpp
+++ b/src/main/service.cpp
@@ -245,7 +245,7 @@ qint64 Service::getEntryTime()
 
 QMap<QString, QString> Service::getShells()
 {
-    qint64 startTime = QDateTime::currentMSecsSinceEpoch();
+
     // 清空原有数据
     m_shellsMap.clear();
     // 需要读取/etc/shells


### PR DESCRIPTION
Delete unused variable startTime in src/main/service.cpp 
Log: Remove unused variable to fix compile warning
Issue: https://github.com/linuxdeepin/open-source-students/issues/65