### PR TITLE
fix: 终端命令查询服务状态无任何返回值

### DIFF
--- a/3rdparty/terminalwidget/lib/Screen.cpp
+++ b/3rdparty/terminalwidget/lib/Screen.cpp
@@ -1644,6 +1644,7 @@ void Screen::setCursorLine(int newLine)
 {
     if (_currentModes[MODE_AppScreen] == 1) {
         _savedState.cursorLine = newLine;
+        _cuY = qBound(0, _cuY, _lines - 1);
     } else {
         _cuY = newLine;
     }

--- a/3rdparty/terminalwidget/lib/Screen.h
+++ b/3rdparty/terminalwidget/lib/Screen.h
@@ -40,7 +40,7 @@
 #define MODE_Cursor    4
 #define MODE_NewLine   5
 #define MODES_SCREEN   6
-#define MODE_AppScreen       (MODES_SCREEN+0)   // Mode #1
+#define MODE_AppScreen 7
 
 namespace Konsole
 {


### PR DESCRIPTION
根因分析：此为bug#115353的衍生bug
解决方案：参考konsole，修改MODE_AppScreen=7、setCursorLine函数做优化

Log: 修复左侧边栏按钮显示异常问题和时间跳转框输入字符异常问题

Bug: https://pms.uniontech.com/bug-view-140547.html