### PR TITLE
fix: use as-needed instead of as-need

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
 endif()
 
 #Use deepin-turbo for Performance optimization
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wl,--as-need -fPIE")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wl,--as-needed -fPIE")
 set(CMAKE_EXE_LINKER_FLAGS "-pie")
 #安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pie -fPIC -z lazy")


### PR DESCRIPTION
Log: Use as-needed to enhance compatibility with linker

Signed-off-by: Han Gao <rabenda.cn@gmail.com>