### PR TITLE
fix: don't ignore CMAKE_EXE_LINKER_FLAGS specified by system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 #Use deepin-turbo for Performance optimization
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wl,--as-needed -fPIE")
-set(CMAKE_EXE_LINKER_FLAGS "-pie")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 #安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pie -fPIC -z lazy")
 


### PR DESCRIPTION
Append to CMAKE_EXE_LINKER_FLAGS instead of overriding them.

Log: Don't ignore CMAKE_EXE_LINKER_FLAGS specified by system