### PR TITLE
fix: Fail to compile under Debug build type

### DIFF
--- a/src/main/terminalapplication.cpp
+++ b/src/main/terminalapplication.cpp
@@ -11,6 +11,10 @@
 // qt
 #include <QDebug>
 
+#ifdef QT_DEBUG
+#include <QTranslator>
+#endif
+
 TerminalApplication::TerminalApplication(int &argc, char *argv[]) : DApplication(argc, argv)
 {
     Utils::set_Object_Name(this);


### PR DESCRIPTION
QTranslator declaration was not included in terminalapplication.cpp under Debug build type.