### PR TITLE
feat: 废弃DDE-Daemon字体接口，改用fontconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ find_package(Qt5Network REQUIRED)
 find_package(Qt5X11Extras REQUIRED)
 
 include(FindPkgConfig)
+include(FindFontconfig)
 
 pkg_search_module(DtkWidget REQUIRED dtkwidget)
 pkg_search_module(DtkGui REQUIRED dtkgui)
@@ -114,6 +115,7 @@ set(LINK_LIBS
     ${LIBSECRET_LIBRARIES}
     ${XCB_EWMH_LIBRARIES}
     ${Qt5X11Extras_LIBRARIES}
+    ${Fontconfig_LIBRARIES}
 )
 
 # Populate a CMake variable with the sources

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Build-Depends:
  libsecret-1-dev,
  libgtest-dev,
  libgmock-dev,
- libxcb-ewmh-dev
+ libxcb-ewmh-dev,
+ fontconfig
 Standards-Version: 4.5.1
 Homepage: https://www.deepin.com/
 

--- a/src/common/define.h
+++ b/src/common/define.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -8,6 +8,7 @@
 
 #include <QtGlobal>
 #include <QString>
+#include <QStringList>
 /*
    TERMINALWIDGET_VERSION is (major << 16) + (minor << 8) + patch.
    can be used like #if (TERMINALWIDGET_VERSION >= QT_VERSION_CHECK(0, 7, 1))
@@ -52,5 +53,15 @@ enum SearchBar_State {
 // 快捷键转换
 const QString SHORTCUT_CONVERSION_UP = "~!@#$%^&*()_+{}:\"|<>?";
 const QString SHORTCUT_CONVERSION_DOWN = "`1234567890-=[];'\\,./";
+
+// Fonts blacklist
+const QStringList FONT_BLACKLIST = {
+    QStringLiteral("Symbol"),
+    QStringLiteral("webdings"),
+    QStringLiteral("MT Extra"),
+    QStringLiteral("Wingdings"),
+    QStringLiteral("Wingdings 2"),
+    QStringLiteral("Wingdings 3")
+};
 
 #endif // DTNG_DEFINE_H

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -402,45 +402,7 @@ public:
         }
         return nullptr;
     }
+    static FontDataList getFonts();
 };
-
-/*******************************************************************************
- 1. @类名:    FontFilter
- 2. @作者:    ut000610 daizhengwen
- 3. @日期:    2020-08-11
- 4. @说明:    打印DBUS获取等宽字体和比较字体字符方法获取等宽字体，用来定位DBUS获取字体失败后的问题
-*******************************************************************************/
-/******** Add by ut001000 renfeixiang 2020-06-15:增加 处理等宽字体的类 Begin***************/
-class FontFilter : public QObject
-{
-    Q_OBJECT
-public:
-    static FontFilter *instance();
-    FontFilter();
-    ~FontFilter();
-    //启动thread，打印等宽字体函数
-    /**
-     * @brief 启动thread，打印等宽字体函数
-     * @author ut001000 任飞翔
-     */
-    void handleWidthFont();
-    /**
-     * @brief 设置线程结束标志
-     * @param stop true = 结束 false = 正常
-     */
-    void setStop(bool stop);
-
-private:
-    /**
-     * @brief 打印DBUS获取等宽字体和比较字体字符方法获取等宽字体，用来定位DBUS获取字体失败后的问题
-     * @author ut001000 任飞翔
-     */
-    void compareWhiteList();
-    //线程成员变量
-    QThread *m_thread = nullptr;
-    //线程结束标志位
-    bool m_bstop = false;
-};
-/******** Add by ut001000 renfeixiang 2020-06-15:增加 处理等宽字体的类 End***************/
 
 #endif

--- a/src/main/dbusmanager.cpp
+++ b/src/main/dbusmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -77,57 +77,6 @@ void DBusManager::callKDESetCurrentDesktop(int index)
         qInfo() << "call setCurrentDesktop Fail!" << response.errorMessage();
 }
 
-FontDataList DBusManager::callAppearanceFont(QString fontType)
-{
-    FontDataList rList;
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(APPEARANCESERVICE, APPEARANCEPATH, APPEARANCESERVICE, "List");
-
-    msg << fontType;
-
-    QDBusMessage response = QDBusConnection::sessionBus().call(msg);
-    if (QDBusMessage::ReplyMessage == response.type()) {
-        qInfo() << "call List Success!";
-        QList<QVariant> list = response.arguments();
-        QString fonts = list.value(list.count() - 1).toString();
-        // 原本的返回值为QDBusPendingReply<QString> => QString
-        fonts.replace("[", "");
-        fonts.replace("]", "");
-        fonts.replace("\"", "");
-        // 用逗号分隔
-        QStringList fontList = fonts.split(",");
-        rList = callAppearanceFont(fontList, fontType);
-    } else {
-        qInfo() << "call List Fail!" << response.errorMessage();
-    }
-
-
-    return rList;
-}
-
-FontDataList DBusManager::callAppearanceFont(QStringList fontList, QString fontType)
-{
-    FontDataList retList;
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(APPEARANCESERVICE, APPEARANCEPATH, APPEARANCESERVICE, "Show");
-
-    msg << fontType << fontList;
-    QDBusMessage response = QDBusConnection::sessionBus().call(msg);
-    if (response.type() == QDBusMessage::ReplyMessage) {
-        qInfo() << "call Show Success!";
-        QByteArray fonts = response.arguments().value(0).toByteArray();
-        QJsonArray array = QJsonDocument::fromJson(fonts).array();
-        for (int i = 0; i < array.size(); i++) {
-            QJsonObject object = array.at(i).toObject();
-            retList.append(FontData(object["Id"].toString(), object["Name"].toString()));
-        }
-        qInfo() << "Show value" << retList.values();
-    } else {
-        qInfo() << "call Show Fail!" << response.errorMessage();
-    }
-    return retList;
-}
-/******** Add by ut001000 renfeixiang 2020-06-16:增加 调用DBUS的show获取的等宽字体，并转换成QStringList End***************/
 void DBusManager::callTerminalEntry(QStringList args)
 {
     QDBusMessage msg =

--- a/src/main/dbusmanager.h
+++ b/src/main/dbusmanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -18,10 +18,6 @@
 // kwin dbus
 #define KWINDBUSSERVICE "org.kde.KWin"
 #define KWINDBUSPATH "/KWin"
-
-// deepin Appearance
-#define APPEARANCESERVICE "org.deepin.dde.Appearance1"
-#define APPEARANCEPATH "/org/deepin/dde/Appearance1"
 
 // sound effect 音效服务
 //#define SOUND_EFFECT_SERVICE    "com.deepin.daemon.SoundEffect"
@@ -85,16 +81,6 @@ public:
      * @param index
      */
     static void callKDESetCurrentDesktop(int index);
-
-    // Appearance
-    /**
-     * @brief callAppearanceFont 获取有效的字体列表
-     * @param fontList 字体id-list
-     * @param fontType 字体类型如：monospacefont、otherfailfont
-     * @return
-     */
-    static FontDataList callAppearanceFont(QStringList fontList, QString fontType);
-    static FontDataList callAppearanceFont(QString fontType);
 
     // deepin terminal
     // 创建窗口

--- a/src/main/service.cpp
+++ b/src/main/service.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -314,7 +314,6 @@ void Service::showSettingDialog(MainWindow *pOwner)
         }
         //更新设置的等宽字体
         Settings::instance()->handleWidthFont();
-        FontFilter::instance()->handleWidthFont();
 
         // 重新加载shell配置数据
         Settings::instance()->reloadShellOptions();

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -555,7 +555,7 @@ bool Settings::isShortcutConflict(const QString &Name, const QString &Key)
 /******** Add by ut001000 renfeixiang 2020-06-15:增加 每次显示设置界面时，更新设置的等宽字体 Begin***************/
 void Settings::handleWidthFont()
 {
-    FontDataList Whitelist = DBusManager::callAppearanceFont("monospacefont");
+    FontDataList Whitelist = Utils::getFonts();
 
     //将新安装的字体，加载到字体库中
     QFontDatabase base;
@@ -613,14 +613,13 @@ QPair<QWidget *, QWidget *> Settings::createFontComBoBoxHandle(QObject *obj)
 {
     auto option = qobject_cast<DTK_CORE_NAMESPACE::DSettingsOption *>(obj);
 
-    /******** Modify by ut001000 renfeixiang 2020-06-15:修改 comboBox修改成成员变量，修改DBUS获取失败场景，设置成系统默认等宽字体 Begin***************/
     comboBox = new DComboBox;
     comboBox->setObjectName("SettingsFontFamilyComboBox");//Add by ut001000 renfeixiang 2020-08-14
 
     QPair<QWidget *, QWidget *> optionWidget =
         DSettingsWidgetFactory::createStandardItem(QByteArray(), option, comboBox);
 
-    FontDataList Whitelist = DBusManager::callAppearanceFont("monospacefont");
+    FontDataList Whitelist = Utils::getFonts();
 
     std::sort(Whitelist.begin(), Whitelist.end(), [ = ](const FontData & str1, const FontData & str2) {
         QCollator qc;
@@ -629,9 +628,8 @@ QPair<QWidget *, QWidget *> Settings::createFontComBoBoxHandle(QObject *obj)
 
     qInfo() << "createFontComBoBoxHandle get system monospacefont";
     if (Whitelist.size() <= 0) {
-        //一般不会走这个分支，除非DBUS出现问题
-        qInfo() << "DBusManager::callAppearanceFont failed, get control font failed.";
-        //DBUS获取字体失败后，设置系统默认的等宽字体
+        qInfo() << "Failed to get monospacefonts from FontConfig";
+        //获取字体失败后，设置系统默认的等宽字体
         QStringList fontlist;
         fontlist << "Courier 10 Pitch" << "DejaVu Sans Mono" << "Liberation Mono"
                  << "Noto Mono" << "Noto Sans Mono" << "Noto Sans Mono CJK JP"
@@ -642,7 +640,6 @@ QPair<QWidget *, QWidget *> Settings::createFontComBoBoxHandle(QObject *obj)
     for(int k = 0; k < Whitelist.count(); k ++) {
         comboBox->addItem(Whitelist[k].value, Whitelist[k].key);
     }
-    /******** Modify by ut001000 renfeixiang 2020-06-15:修改 comboBox修改成成员变量，修改DBUS获取失败场景，设置成系统默认等宽字体 End***************/
 
     if (option->value().toString().isEmpty())
         option->setValue(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());

--- a/tests/src/common/ut_utils_test.cpp
+++ b/tests/src/common/ut_utils_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -378,17 +378,6 @@ TEST_F(UT_Utils_Test, parseNestedQString)
     str = QString("bash -c ping 127.0.0.1");
     QStringList paraList2 = Utils::parseNestedQString(str);
     EXPECT_EQ(paraList.size(), 3);
-}
-
-TEST_F(UT_Utils_Test, FontFilterTest)
-{
-    FontFilter *ff = FontFilter::instance();
-    ff->handleWidthFont();
-
-    ff->setStop(true);
-    EXPECT_EQ(ff->m_bstop, true);
-
-    ff->compareWhiteList();
 }
 
 #endif

--- a/tests/src/settings/ut_settings_test.cpp
+++ b/tests/src/settings/ut_settings_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2023 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -220,8 +220,6 @@ TEST_F(UT_Settings_Test, handleWidthFont)
 {
     Stub stub;
     stub.set((int (QComboBox::*)(const QString &, Qt::MatchFlags) const)ADDR(DComboBox, findText), ut_combobox_findText);
-    //静态重载函数的打桩
-    stub.set((FontDataList (*)(QString))ADDR(DBusManager, callAppearanceFont), ut_DBusManager_callAppearanceFont);
 
     //获取等宽字体
     Settings::instance()->handleWidthFont();


### PR DESCRIPTION
字体功能将不再依赖DDE-Daemon提供的接口，改为使用fontconfig来获取．
基本保持和DDE-Daemon对应接口的实现一致．
fix https://github.com/linuxdeepin/developer-center/issues/3392

Log: 废弃DDE-Daemon字体接口，改用fontconfig