### PR TITLE
fix: wrong default value for quake window config

### DIFF
--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -379,7 +379,7 @@
                             "step": 50,
                             "max": 450,
                             "min": 100,
-                            "default": 450
+                            "default": 9
                         }
                     ]
                 },


### PR DESCRIPTION
在 settings.cpp 中设置的值会除于step再进行存储
而默认值缺没有进行运算，直接使用的最大值

close linuxdeepin/developer-center#3850
