### PR TITLE
fix: Useless last executed command after ssh login

### DIFF
--- a/src/remotemanage/remotemanagementplugn.cpp
+++ b/src/remotemanage/remotemanagementplugn.cpp
@@ -103,7 +103,7 @@ void RemoteManagementPlugin::doCennectServer(ServerConfig *curServer)
     if (nullptr != curServer) {
 
         QString shellFile = createShellFile(curServer);
-        QString strTxt = "expect -f " + shellFile + "\n";
+        QString strTxt = "expect -f " + shellFile + " ; history -d $(history 1) \n";
         //--added by qinyaning(nyq) to solve the probelm which Connecting to the remote server
         /*does not connect to the remote server directly in the new TAB. time: 2020.4.13 18:15
          * */


### PR DESCRIPTION
Remote control uses a temporary script to do the remote login. However, it will leave an useless last executed command which cannot be ran again. This commit erases the login script execution history after login.

Fix: https://github.com/linuxdeepin/developer-center/issues/4037
Log: Useless last executed command after ssh login