### PR TITLE
feat:  终端设置增加在双击选中区域包含特殊符号选项

### DIFF
--- a/3rdparty/terminalwidget/lib/qtermwidget.cpp
+++ b/3rdparty/terminalwidget/lib/qtermwidget.cpp
@@ -615,6 +615,11 @@ void QTermWidget::setTextCodec(QTextCodec *codec)
     m_impl->m_session->setCodec(codec);
 }
 
+void QTermWidget::setTerminalWordCharacters(const QString &wc)
+{
+    m_impl->m_terminalDisplay->setWordCharacters(wc);
+}
+
 /*******************************************************************************
  1. @函数:    setColorScheme
  2. @作者:    ut000125 sunchengxi

--- a/3rdparty/terminalwidget/lib/qtermwidget.h
+++ b/3rdparty/terminalwidget/lib/qtermwidget.h
@@ -119,6 +119,8 @@ public:
     // Text codec, default is UTF-8
     void setTextCodec(QTextCodec *codec);
 
+    void setTerminalWordCharacters(const QString &wc);
+
     /** @brief Sets the color scheme, default is white on black
      *
      * @param[in] name The name of the color scheme, either returned from

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -313,12 +313,17 @@
                             "i18n_skip_keys": ["items"]
                         },
                         {
+                            "key": "include_special_characters_in_double_click_selections",
+                            "name": "Include special character(s) in double click selections",
+                            "type": "lineedit",
+                            "default": ":@-./_~"
+                        },
+                        {
                             "key": "cursor_blink",
                             "type": "checkbox",
                             "text": "Cursor blink",
                             "default": true
                         },
-                          
                         {
                             "key": "auto_copy_selection",
                             "type": "checkbox",

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -309,6 +309,11 @@ void Settings::initConnection()
         emit cursorBlinkChanged(value.toBool());
     });
 
+    QPointer<DSettingsOption> wordCharacters = settings->option("advanced.cursor.include_special_characters_in_double_click_selections");
+    connect(wordCharacters, &Dtk::Core::DSettingsOption::valueChanged, this, [ = ](QVariant value) {
+        emit wordCharactersChanged(value.toString());
+    });
+
     QPointer<DSettingsOption> backgroundBlur = settings->option("advanced.window.blurred_background");
     connect(backgroundBlur, &Dtk::Core::DSettingsOption::valueChanged, this, [ = ](QVariant value) {
         emit backgroundBlurChanged(value.toBool());
@@ -512,6 +517,11 @@ void Settings::setExtendColorScheme(const QString &name)
         return;
     }
     settings->option("basic.interface.expand_theme")->setValue(name);
+}
+
+QString Settings::wordCharacters() const
+{
+    return settings->option("advanced.cursor.include_special_characters_in_double_click_selections")->value().toString();
 }
 
 /*******************************************************************************

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -101,6 +101,7 @@ public:
      * @author ut001121 zhangmeng
      * @return
      */
+    QString wordCharacters() const;
     bool PressingScroll();
     /**
      * @brief 设置界面获取输出时是否是滚动
@@ -305,6 +306,7 @@ signals:
     void OutputScrollChanged(bool enabled);
     void fontSizeChanged(int fontSize);
     void fontChanged(QString fontName);
+    void wordCharactersChanged(QString wordCharacters);
     void historySizeChanged(int historySize);
 
     // 设置中的标签标题格式变化

--- a/src/settings/settings_translation.cpp
+++ b/src/settings/settings_translation.cpp
@@ -144,4 +144,6 @@ void GenerateSettingTranslate()
     Q_UNUSED(shell_profile);
     auto history_size = QObject::tr("History size");
     Q_UNUSED(history_size);
+    auto include_special_characters_in_double_click_selectionisText = QObject::tr("Include special character(s) in double click selections");
+    Q_UNUSED(include_special_characters_in_double_click_selectionisText);
 }

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -46,6 +46,7 @@ TermWidget::TermWidget(const TermProperties &properties, QWidget *parent) : QTer
 
     qInfo() << "Setting initial history size:" << Settings::instance()->historySize();
     setHistorySize(Settings::instance()->historySize());
+    setTerminalWordCharacters(Settings::instance()->wordCharacters());
 
     QString strShellPath = Settings::instance()->shellPath();
     // set shell program
@@ -1118,6 +1119,11 @@ void TermWidget::onSettingValueChanged(const QString &keyName)
     if ("advanced.scroll.scroll_on_output" == keyName) {
         qInfo() << "settingValue[" << keyName << "] changed to " << Settings::instance()->OutputtingScroll()
                 << ", auto effective when happen";
+        return;
+    }
+    
+    if ("advanced.cursor.include_special_characters_in_double_click_selections" == keyName) {
+        setTerminalWordCharacters(Settings::instance()->wordCharacters());
         return;
     }
 

--- a/translations/deepin-terminal.ts
+++ b/translations/deepin-terminal.ts
@@ -223,377 +223,382 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="18"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="20"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="22"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="24"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="26"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="28"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="30"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Quake window animation speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="32"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="34"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="36"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="38"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="40"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="42"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="44"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="46"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="48"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="50"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="52"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="54"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="56"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="58"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
         <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="60"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="62"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="64"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="66"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="100"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="102"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="104"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="106"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="108"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="110"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="112"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="124"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="126"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="128"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="130"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="132"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="134"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="136"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="138"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="140"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="142"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="144"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="146"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
         <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="68"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="70"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="72"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="74"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="76"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="78"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="80"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="82"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="84"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="86"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="88"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="90"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="507"/>
-        <location filename="../src/settings/settings_translation.cpp" line="92"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1167"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1175"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1205"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="94"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="96"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="98"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="114"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
@@ -767,13 +772,13 @@
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="120"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="122"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -981,32 +986,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="709"/>
+        <location filename="../src/settings/settings.cpp" line="718"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="714"/>
+        <location filename="../src/settings/settings.cpp" line="723"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-terminal_az.ts
+++ b/translations/deepin-terminal_az.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Ad:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Əmr:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Qısayollar:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Tələb olunur</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Command əlavə et</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Əmrə düzəliş</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Əmri silmək</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Ad daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Əmr daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Bu ad artıq var</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>lütfən başqasını seçin</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Command əlavə et</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Hələki heç bir əmr yoxdur</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Fərdi əmrlər</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Axtar</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Fərdi mövzu</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Tərz:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>İşıqlı</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Tünd</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Ön rəng:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Arxa rəng:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>PS1 dəvəti:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>PS2 dəvəti:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiqlə</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Serveri silmək</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>%1 silmək istədiyinizə əminsiniz?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Yeni pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Tənzimləmələr</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Bağla</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Fayl yüklənəcək yolu yazın</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Fərdi mövzu</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiqlə</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>İş sahəsini bağla</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Başqa iş sahələrini bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>&quot;%1&quot; tapılmadı, əvəzinə &quot;%2&quot; başladılır. Lütfən üz qabığı profilini yoxlayın.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; açıla bilmədi, onu başlatmaq mümkün deyil</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; tapılmadı, onu başlatmaq mümkün olmadı</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Ctrl+S basmaqla çıxış dayandırıldı. Davam etmək üçün Ctrl+Q vurun.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Vərəq başlığı formatı</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Uzaq vərəq başlığı formatı</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Başlığın adını dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Vərəqi bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Başqa vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Seçimi kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Kursor sayrışır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Kursor tərzi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Düyməyə vurmaqla sürüşdürmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Çıxışda sürüşdürmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Fokus itirildikdən sonra Quake Terminalı gizlətmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Bulanıq arxa fon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Başlanğıcda istifadə etmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Şrift</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Şrift ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Qeyri-şəffaflıq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Təkmilləşmiş</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Sürüşdürmə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Əsas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>İnterfeys</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Qısayollar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Digəriləri</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>İş sahəsi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Fərdi əmrlər</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Uzaqdan idarəetmə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Standart ölçü</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Əlavə et</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Axtar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Sonra əmrə keçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Əvvəlki əmrə keçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Yaxınlaşdır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Uzaqlaşdır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Digər pəncərələri bağla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Pəncərəni bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Üfüqi bölünmə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Yeni vərəq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Növbəti vərəq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Əvvəlki vərəq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Sol iş sahəsini seçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Aşağı iş sahəsini seçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Sağ iş sahəsini seçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Yuxarı iş sahəsini seçmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Şaquli bölünmə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Vərəq başlıqları</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>1 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>2 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>3 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>4 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>5 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>6 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>7 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>8 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>9 vərəqə keçid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+S, Ctrl+Q istifadə edərək axını idarə edin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Üz qabığı profili</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Ad 32 işarədən böyük olmamalıdır</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Məxfi açar faylını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Seçmək</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal, iş sahələri, çoxsaylı pəncərələr, uzaqdan idarəetmə, sürüşüb açılma rejimi və digər xüsusiyyətləri ilə birlikdə təkmilləşdirilmiş terminaldır.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Vərəqlər</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Fokusu &quot;+&quot; nişanına dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Vərəqi seçmək</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Yükləmək üçün faylı seçin</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Yükləmək</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Fayl saxlanılacaq qovluğu seçin</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>lütfən başqasını təyin edin.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Bu terminal bağlanılsın?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Hələ də terminalda işləyən proseslər var. Terminalı bağlamaq onlar sonlanacaq.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Bu terminalda hələ də işləyən %1 proses var. Terminalı bağlamaq onların hamısını sonlandıracaq.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Bu pəncərə baölansın?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Bu pəncərədə hələ də işləyən proseslər var. Pəncərənin bağlanması onların hamısını sonlandıracaq.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Proqramlar hələ də terminalda işləyir</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Bunu silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Bu tətbiqi silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Terminaldan artıq istifadə edə bilməyəcəksiniz.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>İş qovluğunu təyin edin</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Başlanğıcda pəncərə rejimini təyin etmək</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Əmri terminalda icra etmək</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Skript sətrini terminalda başlatmaq</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Sürüşüb açılan rejimi işə salmaq</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Əmr başa çatdıqda terminalı açıq saxlamaq</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Server əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Hələlik heç bir server yoxdur</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Uzaqdan idarəetmə</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Faylları göndərmək və endirmək üçün sağ klik etmədən öncə rz və sz əmrlərinin quraşdırıldığına əmin olun.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Axtar</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Əlavə seçimlər</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Server əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Serverin adı:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Tələb olunur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>İstifadəçi adı:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Şifrə:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Sertifikat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Qrup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Yol:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Əmr:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodlaşma:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Backspace düyməsi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Açarı silmək:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Serveri silmək</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Serverə düzəliş</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Lütfən server adını daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Lütfən İP ünvanını daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Lütfən portu daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Lütfən istifadıçi adını daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Server adı artıq mövcuddur,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>lütfən başqasını daxil edin. </translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normal pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Ekranı bölmək</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1 qısayolu səhvdir, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>%1 qısayolu artıq istifadə olunur, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Yerləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>istifadəçi_adı: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>istifadəçi_adı@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>uzaq host: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>sesiya nömrəsi: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>üz qabığının təyin etdiyi başlıq: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>proqramın adı: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>cari qovluq (qısa): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>cari qovluq (uzun): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>lokal host: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Əlavə et</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Fayl menecerində açmaq</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Üfüqi bölünmə</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Şaquli bölünmə</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Yeni vərəq</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çıx</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Axtar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kodlaşma:</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Fərdi əmrlər</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Uzaqdan idarəetmə</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Fayl göndərmək</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Fayl endirmək</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Tənzimləmələr</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Bağla</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_bo.ts
+++ b/translations/deepin-terminal_bo.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>མིང་། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>བཀའ།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>མྱུར་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>ངེས་པར་འབྲི་དགོས། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>བཀའ་སྣོན་པ། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>རྩོམ་སྒྲིག་བཀའ། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>བཀའ་སུབ་པ། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>ཁ་སྣོན།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>ཉར་གསོག་</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>མིང་འཇུག་རོགས། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>བཀའ་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>མིང་འདི་མིན་འདུག</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>ཡང་བསྐྱར་འཇུག་རོགས། </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ།</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>བཀའ་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>རང་སྒྲུབ་བཀའ། </translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>བཤེར་འཚོལ།</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>རང་སྒྲུབ་བརྗོད་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>བརྗོད་གཞིའི་ཁྱད་ཆོས།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>མདོག་ཧར་པོ།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>མདོག་སྣུམ་་པོ།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>མདུན་གྱི་ཚོས་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>རྒྱབ་ཀྱི་ཚོས་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>ཟུར་སྟོན་བརྡ་རྟགས། PS1</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>ཟུར་སྟོན་བརྡ་རྟགས། PS2</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ། </translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>ཞབས་ཞུ་ཆས་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>ཁྱོད་ཀྱིས་ %1སུབ་རྒྱུ་གཏན་ཁེལ་ལམ།</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>སྒེའུ་ཁུང་གསར་པ་བཟོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>སྒོ་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>ཕབ་ལེན་ཡིག་ཆའི་འགྲོ་ལམ་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>རང་སྒྲུབ་བརྗོད་གཞི།</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ། </translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>ལས་ཀྱ་བྱེད་ཡུལ་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>ལས་ཀ་བྱེད་ཡུལ་གཞན་དག་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>“%1”རྙེད་མེད་པས། “%2”ཚབ་བྱས་པ། Shellསྒྲིག་འགོད་ལ་ཞིབ་བཤེར་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot;ཕྱེ་མི་ཐུབ་པས། རྒྱུན་ལྡན་ལྟར་སྤྱོད་ཐབས་བྲལ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>“%1”རྙེད་མེད་པས། རྒྱུན་ལྡན་ལྟར་བེད་སྤྱོད་བྱ་ཐབས་བྲལ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Ctrl+Sམནན་ནས་བཀལ་ཟིན་པས། Ctrl+Qམནན་ན་མུ་མཐུད་བེད་སྤྱོད་བྱེད་ཆོག </translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>གདོང་འཛར་ཁ་བྱང་གི་རྣམ་གཞག</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>རྒྱང་སྦྲེལ་གདོང་འཛར་ཁ་བྱང་གི་རྣམ་གཞག </translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>ཁ་བྱང་གི་མིང་བསྐྱར་འདོགས།</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>གདོང་འཛར་ཤོག་ངོས་ཁ་རྒྱག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>གདོང་འཛར་ཤོག་ངོས་གཞན་དག་ཁ་རྒྱོབ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>ཡི་གེ་འདེམས་སྐབས་རང་འགུལ་ངང་གཏུབ་པང་ལ་པར་སློག་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>འོད་རྟགས་ཆེམ་ཆེམ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>འོད་རྟགས་བཟོ་ལྟ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>མཐེབ་གཞོང་མནན་སྐབས་འགུལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>ཕྱིར་འདྲེན་སྐབས་འགུལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>འདུ་གནས་བརླག་སྐབས་ཐོག་ལྷ་སྒེའུ་ཁུང་ཡིབ་སྲིད། </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>རྒྱབ་ལྗོངས་མི་གསལ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>འགོ་སློང་དུས་སྤྱོད་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>ཡིག་གཟུགས།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>ཡིག་གཟུགས་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>གསལ་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>མཐོ་རིམ་སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>འོད་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>འགུལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>སྒེའུ་ཁུང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>རྨང་གཞིའི་སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>མཐུད་ཁ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>མྱུར་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>གཞན་དག</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>མཐའ་སྣེ། </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>ལས་ཀ་བྱེད་ས།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>རང་སྒྲུབ་བཀའ། </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་མངོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>རྒྱང་རིང་དོ་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>མཁོ་ཕབ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>སོར་བཞག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>བཀའ་རྗེས་མར་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>བཀའ་སྔ་མར་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>ཆེར་གཏོང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>ཝང་གཏོང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>སྒེའུ་ཁུང་གཞན་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>སྒེའུ་ཁུང་བརྒྱབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>བརྙན་ཡོལ་འཕྲེད་དུ་འབྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>གསར་བཟོས་གདོང་འཛར།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>གདོང་འཛར་ཤོག་ལྷེ་རྗེས་མ། </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>གདོང་འཛར་ཤོག་ལྷེ་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>གཡོན་གྱི་ལས་ཀ་བྱེད་ཁུལ་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>གཤམ་གྱི་ལས་ཀ་བྱེད་ཁུལ་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>གཡས་ཀྱི་ལས་ཀ་བྱེད་ཁུལ་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>གོང་གི་ལས་ཀ་བྱེད་ཁུལ་འདེམས་པ། </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>བརྙན་ཡོལ་གཞུང་དུ་འབྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>འཚོལ་བཤེར།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>གདོང་འཛར་གྱི་ཁ་བྱང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>གདོང་འཛར་1བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>གདོང་འཛར་2བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>གདོང་འཛར་3བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>གདོང་འཛར་4བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>གདོང་འཛར་5བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>གདོང་འཛར་6བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>གདོང་འཛར་7བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>གདོང་འཛར་8བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>གདོང་འཛར་9བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+Sདང་Ctrl+Qསྤྱད་དེ་ཚོད་འཛིན་བྱེད་མི་ཆོག </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shellསྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>མིང་གི་རིང་ཐུང་ཡིག་རྟགས་32ལས་བརྒལ་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>སྒེར་གྱི་ཡིག་ཆ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>ཡིག་བརྙན་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>མཐའ་སྣེ་ནི་ལས་ཀ་བྱེད་ཡུལ་དང་། སྒེའུ་ཁུང་མང་བ། རྒྱང་རིང་དོ་དམ། ཐོག་ལྷའི་དཔེ་རྣམ་སོགས་བྱེད་ནུས་འདུ་བའི་མཐའ་སྣེའི་དཔེ་ལད་ཆས་ཤིག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>གདོང་འཛར་ཤོག་ངོས། </translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>འོད་རྟགས་མདོ་ཚེག་པར་རིས་“+”ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>གདོང་འཛར་ཤོག་ངོས་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>སྐྱེལ་འཇོག་བྱེད་པའི་ཡིག་ཆ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>སྐྱེལ་འཇོག</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>ཕབ་ལེན་བྱས་པའི་ཡིག་ཆའི་ཉར་ཚགས་དཀར་ཆག་བྱ་ཡུལ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>ཡང་བསྐྱར་སྒྲིག་འགོད་བྱེད་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>མཐའ་སྣེ་འདི་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>མཐའ་སྣེ་འདིར་ད་རུང་བྱ་རིམ་1བཀོལ་སྤྱོད་བྱེད་བཞིན་ཡོད་པས། མཐའ་སྣེ་ཁ་རྒྱག་ན་བྱ་རིམ་ཡང་ཁ་རྒྱག་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>མཐའ་སྣེ་འདིར་ད་རུང་བྱ་རིམ་%1བཀོལ་སྤྱོད་བྱེད་བཞིན་ཡོད་པས། མཐའ་སྣེ་ཁ་རྒྱག་ན་བྱ་རིམ་ཡང་ཁ་རྒྱག་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>སྒེའུ་ཁུང་འདི་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>སྒེའུ་ཁུང་ནང་གི་མཐའ་སྣེ་འགར་ད་དུང་བྱ་རིམ་བཀོལ་སྤྱོད་བྱེད་བཞིན་ཡོད་པས། སྒེའུ་ཁུང་ཁ་རྒྱག་ན་བྱ་རིམ་ཡང་ཁ་རྒྱག་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>མཐའ་སྣེར་སྔར་བཞིན་བཀོལ་སྤྱོད་བྱེད་བཞིན་པའི་བྱ་རིམ་འདུག</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>ཁྱེད་ཀྱིས་དེ་བཤིག་འདོན་བྱ་རྒྱུ་གཏན་ཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>ཁྱེད་ཀྱིས་མཐའ་སྣེ་བཤིག་འདོན་བྱ་རྒྱུ་གཏན་ཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>བཤིག་འདོན་བྱས་རྗེས་ཉེར་སྤྱོད་འདི་སྤྱོད་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>མཐའ་སྣེའི་འགོ་སློང་དཀར་ཆག་སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>མཐའ་སྣེའི་འགོ་སློང་བའི་དཔེ་རྣམ་སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>མཐའ་སྣེའི་ཁྲོད་དུ་བྱ་རིམ་  བཀོལ་བཞིན་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>མཐའ་སྣེའི་ཁྲོད་འཁྲབ་དེབ་ཡིག་རྟགས་ཕྲེང་བ་ཡོད་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>མཐའན་སྣེ་ཡིས་ཐོག་ལྷའི་དཔེ་རྣམ་ལྟར་འགོ་སློང་རྒྱུ་སྒྲིག་འགོད་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>མཐའ་སྣེས་བཀའ་འམ་འཁྲབ་གཞུང་ལག་བསྟར་བྱས་རྗེས་ཀྱི་འབྲས་བུ་མངོན་རྒྱུ་སྒྲིག་འགོད་བྱ་རྒྱུ།</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>ཞབས་ཞུ་ཆས་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>རྒྱང་སྦྲེལ་དོ་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>ཁྱེད་ཀྱིས་མཐེབ་གཡས་འདེམས་བྱང་སྤྱད་ནས་ཡིག་ཆ་སྐྱེལ་འཇུག་དང་ཕབ་ལེན་མ་བྱས་གོང་དུ། ཞབས་ཞུ་ཆས་ལ་བཀའ་rzདང་sz སྒྲིག་འཇུག་བྱ་དགོས།</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>བཤེར་འཚོལ།</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>མཐོ་རིམ་གདམ་ག</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>ཞབས་ཞུ་ཆས་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>ཞབས་ཞུ་ཆས་ཀྱི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>ངེས་པར་འབྲི་དགོས། </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>གནས་ཡུལ། </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>མཐུད་ཁ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>སྤྱོད་མཁན་མིང་། </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>གསང་ཨང་། </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>དཔང་ཡིག</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>ཚོ་བགོས།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>ཡིག་ཆའི་འགྲོ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>བཀའ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>ཨང་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>ཕྱིར་བཤོལ་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>སུབ་པའི་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>ཞབས་ཞུ་ཆས་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>ཁ་སྣོན།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>ཞབས་ཞུ་ཆས་རྩོམ་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>ཉར་གསོག་</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>ཞབས་ཞུ་ཆས་ཀྱི་མིང་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation> IP གནས་ཡུལ་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>མཐུད་ཁ་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>སྤྱོད་མཁན་མིང་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>ཞབས་ཞུ་ཆས་འདིའི་མིང་མིན་འདུག</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>ཡང་བསྐྱར་འཇུག་རོགས། </translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ།</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>རྒྱུན་ཅན་སྒེའུ་ཁུང་།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>བརྙན་ཡོལ་འབྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>ཆེ་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1ནི་ཕན་མེད་མྱུར་མཐེབ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>མྱུར་མཐེབ་%1སྤྱོད་བཞིན་ཡོད། </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>བར་འཇུག </translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>སྤྱོད་མཁན་མིང་། %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>སྤྱོད་མཁན་མིང་། @ %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>རྒྱང་སྦྲེལ་རྩིས་འཁོར་ཨ་མ། %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>བགྲོ་གླེང་ཨང་རྟགས། %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>shellསྒྲིག་བཀོད་བྱས་པའི་སྒེའུ་ཁུང་གི་ཁ་བྱང་། %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>བྱ་རིམ་མིང་། %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>མིག་སྔའི་དཀར་ཆག （ཐུང་ངུ་）：%d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>མིག་སྔའི་དཀར་ཆག་（རིང་བ་）：%D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>རང་སའི་རྩིས་འཁོར་ཨ་མ།</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>མཁོ་ཕབ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>ཡིག་ཆ་དོ་དམ་ཆས་ནང་དུ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>བརྙན་ཡོལ་འཕྲེད་དུ་འབྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>བརྙན་ཡོལ་གཞུང་དུ་འབྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>གསར་བཟོས་གདོང་འཛར།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>ཡོལ་གང་ལས་ཕྱིར་འཐེན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>འཚོལ་བཤེར།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>ཨང་སྒྲིག་བྱེད་སྟངས།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>རང་སྒྲུབ་བཀའ། </translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>རྒྱང་སྦྲེལ་དོ་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>ཡིག་ཆ་སྐྱེལ་འཇོག</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>ཡིག་ཆ་ཕབ་ལེན།</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>སྒོ་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ།</translation>

--- a/translations/deepin-terminal_br.ts
+++ b/translations/deepin-terminal_br.ts
@@ -4,63 +4,63 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Anv:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Urzhiad:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Berradurioù:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="209"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="215"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Goulennet</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Ouzhpennañ un urzhiad</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Aozañ an urzhiad</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Dilemel an urzhiad</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="197"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Ouzhpennañ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="199"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="636"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Mat eo</translation>
@@ -78,22 +78,22 @@
         <translation type="vanished">Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="388"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Ebarzhit un anv mar plij</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="402"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Ebarzhit un urzhiad mar plij</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="452"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>An anv-mañ a zo anezhañ dija,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="453"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>ebarzhit unan all mar plij.</translation>
     </message>
@@ -105,15 +105,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Ouzhpennañ un urzhiad</translation>
+    </message>
+    <message>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
+        <source>No commands yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="76"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Urzhiadoù personnelaet</translation>
     </message>
@@ -121,7 +126,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
@@ -129,53 +134,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="425"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="433"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Kadarnaat</translation>
@@ -199,13 +204,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Dilemel ar servijer</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Ha sur oc&apos;h ho peus c&apos;hoant dilemel %1?</translation>
     </message>
@@ -213,24 +218,24 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Prenestr nevez</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Arventennoù</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Serriñ</translation>
@@ -244,12 +249,12 @@
         <translation type="vanished">Serriñ</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1808"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Skrivit an hent evit pellgargañ ar restr</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2090"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -261,368 +266,383 @@
         <translation type="vanished">Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Eilañ an diuzadenn</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation> Blinkadenn ar reti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Doare kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Dibunañ pa vez pouezet war ur bouton</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Dibunañ an ezvont</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Kuzhat ar prenestr Quake ur wech kollet ar fokus gantañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="148"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Disteraat an drek-leur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Implijout el loc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Skritur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Ment ar skritur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="171"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Treuzwelusted</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Araokaet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Reti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Dibunañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Prenestr</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Eeun</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Etrefas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Berradurioù</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1654"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Traoù all</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="37"/>
-        <location filename="../src/main/mainwindow.cpp" line="1652"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Spas-labour</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Urzhiadoù personnelaet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Diskouez ar berradurioù</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Kontrolliñ a-bell</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Adenvel an titl</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Ment dre ziouer</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Pegañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Diuzañ pep-tra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Mont d&apos;an urzhiad da heul</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Mont d&apos;an urzhiad kent</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zoumañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Dizoumañ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Serriñ ar prinistri all</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="493"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Serriñ ar spasoù-labour all</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1153"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1159"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1161"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1207"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Serriñ ar prenestr</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Serriñ ar spas-labour</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Rannañ a-blaen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Rannañ a-blom</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Kavout</translation>
     </message>
@@ -635,52 +655,52 @@
         <translation type="vanished">Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="392"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="639"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>termenit unan all mar plij.</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="40"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Deepin Terminal a zo un emulator terminal araokaet gant spasoù-labour, meur a brenestr, merañ a-bell, ur mod quake hag arc&apos;hweladurioù ouzhpenn.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1650"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1670"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1755"/>
-        <location filename="../src/common/utils.cpp" line="146"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Diuzañ ar restr da bellgas</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1762"/>
-        <location filename="../src/common/utils.cpp" line="151"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Pellgas</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Programmoù a zo war sekutiñ en terminal bepred</translation>
     </message>
@@ -693,55 +713,55 @@
         <translation type="vanished">Kuitaat</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Serriñ an terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="172"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Bez ez eus c&apos;hoazh ur prosesus o vont en-dro e-barzh an terminal-mañ. Serriñ an terminal a lazho hemañ.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Bez ez eus c&apos;hoazh 1% a brosesusoù o vont en-dro e-barzh an terminal-mañ. Serriñ an terminal a lazho an holl anezho.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Serriñ ar prenestr-mañ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Bez ez eus c&apos;hoazh prosesusoù o vont en-dro e-barzh ar prenestr-mañ. Serriñ ar prenestr a lazho ar re-se.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1824"/>
-        <location filename="../src/common/utils.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Diuzit ur c&apos;havlec&apos;h evit enrollañ ar restr</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Ha sur oc&apos;h da gaout c&apos;hoant da zistaliañ an dra-mañ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Ha sur oc&apos;h ho peus c&apos;hoant da zistaliañ an aplikasion-mañ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Ne vo ket posupl deoc&apos;h implijout Terminal ken.</translation>
     </message>
@@ -754,57 +774,57 @@
         <translation type="vanished">Erlec&apos;hiañ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="330"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Sekutiñ un urzhiad en terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="333"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Sekutiñ chadenn ar skript en terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="324"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Spisait ar c&apos;havlec&apos;h labour</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="327"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Spisait mod prenestr el loc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Sekutiñ e mod Quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Mirout an terminal digoret pa echu an urzhiad</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="395"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>N&apos;hall ket bezañ hiroc&apos;h an anv evit 32 arouezenn</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="578"/>
-        <location filename="../src/main/mainwindow.cpp" line="1830"/>
-        <location filename="../src/common/utils.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Diuzañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="574"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Diuzit ar restr alc&apos;hwez prevez</translation>
     </message>
@@ -813,41 +833,41 @@
         <translation type="vanished">Kadarnaat</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="127"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="129"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation type="unfinished">Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Kadarnaat</translation>
@@ -856,20 +876,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="179"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Ouzhpennañ ar servijer</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
+        <source>No servers yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Kontrolliñ a-bell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Bezit asur eo bet staliet an urzhiadoù rz hag sz e-barzh ar servijer a-raok na glikfer dehoù evit pellgas ha pellgargañ ar restroù.</translation>
     </message>
@@ -877,7 +902,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="223"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
@@ -885,95 +910,95 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="67"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Dibarzhioù araokaet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="107"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Ouzhpennañ ar servijer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Anv ar servijer:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="147"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Goulennet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Chomlec&apos;h:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="162"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porzh:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="183"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Anv-implijer:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Ger-tremen:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation> Testeni:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Strollad:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Hent:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="234"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Urzhiad:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="240"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Enkodañ:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Stokell souzañ:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Dilemel an alc&apos;hwez:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="274"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Dilemel ar servijer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="295"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="296"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Ouzhpennañ</translation>
@@ -987,39 +1012,37 @@
         <translation type="vanished">Ouzhpennañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="300"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Aozañ ar servijer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="301"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="409"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="420"/>
         <source>tty</source>
-        <translation>tty</translation>
+        <translation type="vanished">tty</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Ebarzhit un anv-servijer mar plij</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="515"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Ebarzhit ur chomlec&apos;h IP mar plij</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Ebarzhit ur porzh mar plij</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="526"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Ebarzhit un anv-implijader mar plij</translation>
     </message>
@@ -1028,36 +1051,28 @@
         <translation type="vanished">Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="405"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="417"/>
         <source>ascii-del</source>
-        <translation>ascii-del</translation>
+        <translation type="vanished">ascii-del</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="406"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="418"/>
         <source>auto</source>
-        <translation>auto</translation>
+        <translation type="vanished">auto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="407"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="419"/>
         <source>control-h</source>
-        <translation>kontrol-E-barzh</translation>
+        <translation type="vanished">kontrol-E-barzh</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="408"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="416"/>
         <source>escape-sequence</source>
-        <translation>sekañs-achapañ</translation>
+        <translation type="vanished">sekañs-achapañ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="540"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>An anv-servijer a zo anezhañ endeo,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="541"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>ebarzhit unan all mar plij. </translation>
     </message>
@@ -1069,7 +1084,7 @@
         <translation type="vanished">Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="388"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Mat eo</translation>
@@ -1078,38 +1093,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Skramm daouhanteret</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Prenestr normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimom</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="285"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="294"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Ar verradenn-glaver %1 a zo direizh</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="301"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="308"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="314"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Ar verradenn %1 a zo war implij dija,</translation>
     </message>
@@ -1117,55 +1142,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="56"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="105"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1184,90 +1209,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="459"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="462"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Pegañ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="471"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Digeriñ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="475"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Digeriñ ar merer restroù</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="484"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Rannañ a-blaen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="487"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Rannañ a-blom</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="497"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Kuitaat ar skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="506"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="509"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Kavout</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="513"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="523"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Enkodañ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="525"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Urzhiadoù personnelaet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="527"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Kontrolliñ a-bell</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Pellgas ar restr</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="532"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Pellgargañ ar restr</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Arventennoù</translation>
     </message>
@@ -1287,21 +1312,21 @@
         <translation type="vanished">Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Serriñ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Mat eo</translation>

--- a/translations/deepin-terminal_ca.ts
+++ b/translations/deepin-terminal_ca.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Ordre:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Dreceres:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Cal</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Afegeix una ordre</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Edita l&apos;ordre</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Elimina l&apos;ordre</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Afegeix</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Si us plau, escriviu un nom.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Si us plau, escriviu una ordre.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>El nom ja existeix;</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>si us plau, escriviu-ne un altre.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Afegeix una ordre</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Encara no hi ha cap ordre.</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Ordres personalitzades</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema personalitzat</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Estil:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Lleugera</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Fosc</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Color frontal:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Color de fons:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Indicador PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Indicador PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Elimina el servidor</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Segur que voleu eliminar %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Finestra nova</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Configuració</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Escriviu el camí per baixar el fitxer.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema personalitzat</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Tanca l&apos;espai de treball</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Tanca altres espais de treball</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>No s&apos;ha pogut trobar &quot;%1&quot;, s&apos;inicia &quot;%2&quot;. Si us plau, comproveu el perfil de l&apos;intèrpret d&apos;ordres.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>No s&apos;ha pogut obrir &quot;%1&quot;. No es pot executar.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>No s&apos;ha pogut trobar &quot;%1&quot;, no es pot executar.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>La sortida s&apos;ha suspès prement Ctrl+S. Premeu Ctrl+Q per reprendre-la.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format del títol de les pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format remot del títol de les pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Canvia&apos;n el títol</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Tanca la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Tanca les altres pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copia en seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Intermitència del cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Estil del cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Desplaçament en tocar una tecla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Desplaçament en una sortida</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Oculta la finestra desplegable en perdre el focus.</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Fons difuminat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Usa en iniciar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Lletra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Mida de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacitat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avançat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Desplaçament</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Bàsic</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interfície</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Dreceres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Altres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Espai de treball</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Ordres personalitzades</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Gestió remota</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Mida per defecte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Enganxa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Salta a l&apos;ordre següent</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Salta a l&apos;ordre anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Ampliació</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Reducció</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Tanca les altres finestres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Tanca la finestra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Divisió horitzontal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Pestanya nova</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Pestanya següent</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Pestanya anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Selecciona l&apos;espai de treball de l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Selecciona l&apos;espai de treball de baix</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Selecciona l&apos;espai de treball de la dreta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Selecciona l&apos;espai de treball de dalt</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Divisió vertical</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Títols de les pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ves a la pestanya 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ves a la pestanya 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ves a la pestanya 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ves a la pestanya 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ves a la pestanya 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ves a la pestanya 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ves a la pestanya 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ves a la pestanya 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ves a la pestanya 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Inhabiliteu el control de flux amb Ctrl+S, Ctrl+Q.</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Perfil de l&apos;intèrpret</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>El nom no hauria de superar els 32 caràcters.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Selecciona el fitxer de clau privada</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Selecciona</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>El Terminal és un emulador de terminal avançat amb divisió de finestres, espais de treball, gestió remota, mode Quake i altres característiques.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Canvia el focus a la icona &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Selecciona la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Seleccioneu el fitxer per carregar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Carrega</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Seleccioneu un directori per desar-hi el fitxer.</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>si us plau, establiu-ne un/a altre/a.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Voleu tancar aquest terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Encara hi ha un procés que s&apos;executa en aquest terminal. Tancar-lo el matarà.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Encara hi ha %1 processos que s&apos;executen en aquest terminal. Tancar-lo els matarà tots.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Voleu tancar aquesta finestra?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Encara hi ha processos que s&apos;executen en aquesta finestra. Tancar-la els matarà tots.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Encara hi ha programes executant-se al terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Segur que voleu desinstal·lar-la?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Segur que voleu desinstal·lar aquesta aplicació?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Ja no podreu usar més el Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Establiu el directori de treball.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Establiu el mode de finestra a l&apos;inici.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Executa una ordre al terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Executa la cadena de script al terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Execució en mode quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Mantén el terminal obert quan l&apos;odre acabi.</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Afegeix un servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Encara no hi ha cap servidor.</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Gestió remota</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Assegureu-vos que les ordres rz i sz s&apos;han instal·lat al servidor abans de fer clic dret per penjar i baixar fitxers.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opcions avançades</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Afegeix un servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nom de servidor:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Cal</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adreça:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nom d&apos;usuari:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Contrasenya:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Camí:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Ordre:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Codificació:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tecla de retrocés:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Elimina la clau:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Elimina el servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Afegeix</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Edita el servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Si us plau, escriviu un nom de servidor.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Si us plau, escriviu una adreça IP.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Si us plau, escriviu un port.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Si us plau, escriviu un nom d&apos;usuari.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>El nom del servidor ja existeix;</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>si us plau, escriviu-ne un altre.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Finestra normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Divideix la pantalla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Màxim</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>La drecera %1 no és vàlida;</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>La drecera %1 ja s&apos;usava;</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Insereix</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nom d&apos;usuari: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nom d&apos;usuari@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>amfitrió remot: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>número de sessió: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>títol establert per l&apos;intèrpret: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nom del programa: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>directori actual (breu): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>directori actual (extens): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>amfitrió local: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Enganxa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Obre al gestor de fitxers</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Divisió horitzontal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Divisió vertical</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Pestanya nova</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Surt de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Codificació</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Ordres personalitzades</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Gestió remota</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Carrega un fitxer</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Baixa el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Configuració</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>

--- a/translations/deepin-terminal_cs.ts
+++ b/translations/deepin-terminal_cs.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Název: </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Příkaz:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Klávesové zkratky:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Vyžadováno</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Přidat příkaz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Upravit příkaz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Smazat příkaz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Zadejte název</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Zadejte příkaz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Tento název už existuje,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>zadejte jiný.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Přidat příkaz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Zatím žádné příkazy</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Uživatelsky určené příkazy</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Uživatelsky určený motiv vzhledu</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Styl:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Světlý</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Tmavý</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Barva popředí:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Barva pozadí:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Výzva PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Výzva PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Smazat záznam pro server</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Opravdu chcete smazat %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nové okno</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Pro jeho stažení, napište popis umístění souboru</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Uživatelsky určený motiv vzhledu</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Zavřít pracovní plochu</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Zavřít ostatní pracovní plochy</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>„%1“ se nepodařilo najít. Náhradně se spouští „%2“. Zkontrolujte svůj profil pro shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Nepodařilo se otevřít „%1“, není možné ho spustit</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>„%1“ se nedaří najít, není možné ho spustit</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Výstup byl pozastaven stisknutím Ctrl+S. Pokud chcete pokračovat, stiskněte Ctrl+Q.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Formát nadpisu karty</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Formát nadpisu vzdálené karty</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Změnit titulek</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Zavřít kartu</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Zavřít ostatní karty</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopírovat při výběru</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Blikání ukazatele</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Styl ukazatele</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Posunout stisku klávesy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Posunout při výstupu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Při ztrátě zaměření vysouvací okno skrýt</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Rozmazat pozadí</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Použít při spouštění</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Písmo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Velikost písma</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Neprůhlednost</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Pokročilé</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Ukazatel</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Otáčet kolečkem myši</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Základní</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Rozhraní</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Ostatní</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminál</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Pracovní plocha</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Uživatelsky určené příkazy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Správa na dálku</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Celá obrazovka</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Výchozí velikost</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Skočit na další příkaz</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Skočit na předchozí příkaz</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Přiblížit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Oddálit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Zavřít další okna</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Zavřít okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Vodorovné rozdělení</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nová karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Další karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Předchozí karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Vybrat pracovní plochu vlevo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Vybrat pracovní plochu níže</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Vybrat pracovní plochu vpravo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Vybrat pracovní plochu výše</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Svislé rozdělení</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Dlaždice karty</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Přejít na kartu 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Přejít na kartu 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Přejít na kartu 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Přejít na kartu 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Přejít na kartu 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Přejít na kartu 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Přejít na kartu 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Přejít na kartu 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Přejít na kartu 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Řízení toku vypnete pomocí Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil shellu</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Jméno by nemělo být delší než 32 znaků</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Vybrat soubor se soukromým klíčem</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Vybrat</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminál je pokročilým emulátorem terminálu s pracovními plochami, vícero okny, správou na dálku, vysouvacím režimem (quake) a dalšími funkcemi.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Karty</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Přepnout zaměření na ikonu „+“ (plus)</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Vybrat kartu</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Vyberte soubor k nahrání</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Nahrát</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Vyberte složku pro uložení souboru</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>nastavte jiné.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Zavřít tento terminál?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>V tomto terminálu je pořád ještě spuštěný proces. Zavření terminálu vynutí ukončení tohoto procesu.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>V tomto terminálu jsou pořád ještě spuštěné %1 procesy. Zavření terminálu vynutí jejich ukončení.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Zavřít toto okno?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>V tomto okně je pořád ještě spuštěný proces. Zavření okna vynutí ukončení tohoto procesu.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>V terminálu jsou ještě spuštěné programy</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Opravdu ho chcete odinstalovat?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Opravdu chcete tuto aplikaci odinstalovat?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Nadále už nebudete moci Terminál používat.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Nastavit pracovní složku</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Nastavit režim okna při spouštění</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Vykonat příkaz v terminálu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Spustit řetězec skriptu v terminálu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Spustit ve vysouvacím (quake) režimu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Ponechat terminál otevřený i po skončení příkazu</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Přidat server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Zatím žádné servery</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Správa na dálku</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Než budete nahrávat na a stahovat ze serveru soubory pomocí klepnutí pravým tlačítkem myši, ověřte, že jsou na něm nainstalovány příkazy rz a sz.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Pokročilé volby</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Přidat server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Název serveru:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Vyžadováno</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresa:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Číslo portu:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Uživatelské jméno:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Heslo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certifikát:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Skupina:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Umístění:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Příkaz:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kódování znaků:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Klávesa Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Klávesa pro mazání:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Smazat server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Upravit server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Zadejte název serveru</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Zadejte IP adresu serveru</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Zadejte číslo portu</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Zadejte uživatelské jméno</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Tento název serveru už tu existuje,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>zadejte jiný.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Obyčejné okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Rozdělit obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximalizováno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Celá obrazovka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Zkratka %1 není platná</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Zkratka %1 už byla používána, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>uživatelské jméno: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>uživatelské jméno@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>vzdálený stroj: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>číslo relace: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>nadpis nastavený shellem: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>název programu: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>stávající složka (krátce): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>stávající složka (dlouze): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>tento stroj: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Otevřít ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Vodorovné rozdělení</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Svislé rozdělení</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nová karta</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Opustit celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Celá obrazovka</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kódování znaků</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Uživatelsky určené příkazy</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Správa na dálku</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Nahrát soubor</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Stáhnout soubor</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_de.ts
+++ b/translations/deepin-terminal_de.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Befehl:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Tastenkürzel:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Erforderlich</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Befehl hinzufügen </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Befehl bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Befehl löschen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Bitte einen Namen eingeben</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Bitte einen Befehl eingeben</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Der Name existiert bereits,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>bitte einen anderen eingeben.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Befehl hinzufügen </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Noch keine Befehle</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Benutzerdefinierte Befehle</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Benutzerdefiniertes Thema</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stil:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Hell</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Dunkel</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Vordergrundfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Hintergrundfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Server löschen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Sind Sie sicher, dass Sie %1 löschen möchten?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Neues Fenster </translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Geben Sie den Pfad zum Herunterladen der Datei ein</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Benutzerdefiniertes Thema</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Arbeitsfläche schließen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Andere Arbeitsflächen schließen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Die Ausgabe wurde durch Drücken von Strg+S unterbrochen. Zum Fortsetzen Strg+Q drücken.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Tab-Titel-Format</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Titel umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Tab schließen</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Andere Tabs schließen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopieren bei Auswahl</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Cursorblinkgeschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Mauszeiger-Stil</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Bildlauf bei Tastendruck</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Bildlauf bei Ausgabe</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Verstecke das Quake-Fenster, nachdem der Fokus verloren wurde</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Hintergrund weichzeichnen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Beim Startvorgang verwenden</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Schriftart</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Schriftgröße</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Deckkraft</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Mauszeiger</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Bildlauf</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Fenster</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Basis</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Schnittstelle</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Tastenkürzel</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Andere</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Arbeitsfläche</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Benutzerdefinierte Befehle</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Tastenkürzel anzeigen </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Fernverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Standardgröße</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Zum nächsten Befehl springen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Zum vorherigen Befehl springen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Hineinzoomen:</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Hinauszoomen:</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Andere Fenster schließen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Fenster schließen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Horizontal teilen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Neuer Tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Nächster Tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Vorheriger Tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Linke Arbeitsfläche auswählen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Untere Arbeitsfläche auswählen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Rechte Arbeitsfläche auswählen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Obere Arbeitsfläche auswählen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Vertikal teilen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Tab-Titel</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Gehe zu Tab 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Gehe zu Tab 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Gehe zu Tab 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Gehe zu Tab 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Gehe zu Tab 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Gehe zu Tab 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Gehe zu Tab 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Gehe zu Tab 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Gehe zu Tab 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Flusskontrolle mit Strg+S, Strg+Q deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell-Profile</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Der Name sollte nicht länger als 32 Zeichen sein</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Private Schlüsseldatei auswählen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal ist ein fortschrittlicher Terminalemulator mit Arbeitsbereich, mehreren Fenstern, Fernverwaltung, Quake-Modus und anderen Funktionen.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Tabs</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Tab auswählen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Datei zum Hochladen auswählen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Ein Verzeichnis zum Speichern der Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>bitte einen anderen festlegen.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Dieses Terminal schließen?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Es läuft immer noch ein Prozess in diesem Terminal. Das Schließen des Terminals wird ihn beenden.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Es laufen noch %1 Prozesse in diesem Terminal. Das Schließen des Terminals wird alle Prozesse beenden.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Dieses Fenster schließen?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Es laufen noch Prozesse in diesem Fenster. Das Schließen des Fensters wird alle Prozesse beenden.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Es werden noch Programme im Terminal ausgeführt</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Sind Sie sicher, dass Sie es deinstallieren möchten?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Sind Sie sicher, dass Sie diese Anwendung deinstallieren möchten?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Sie können das Terminal nicht länger verwenden.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Arbeitsverzeichnis festlegen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Fenstermodus beim Start festlegen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Einen Befehl im Terminal ausführen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Skriptzeichenfolge im Terminal ausführen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Im Quake-Modus ausführen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Terminal offen lassen, wenn der Befehl abgeschlossen ist</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Server hinzufügen </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Noch keine Server</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Fernverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Bitte stellen Sie sicher, dass die Befehle rz und sz auf dem Server installiert sind, bevor Sie mit der rechten Maustaste klicken, um Dateien hoch- oder herunterzuladen.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Erweiterte Optionen </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Server hinzufügen </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Servername:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Erforderlich</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresse:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Benutzername:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Passwort:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Zertifikat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Gruppe:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Pfad:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Befehl:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodierung:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Rücklauftaste:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Taste löschen:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Server löschen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Server bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Bitte einen Servername eingeben</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Bitte eine IP-Adresse eingeben</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Bitte einen Port eingeben</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Bitte einen Benutzernamen eingeben</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Der Servername existiert bereits,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>bitte einen anderen eingeben.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normales Fenster</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Geteilter Bildschirm</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Das Kürzel %1 ist ungültig, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Das Tastenkürzel %1 ist bereits in Verwendung,</translation>
     </message>
@@ -1008,146 +1035,146 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>Benutzername: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>Benutzername@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>Sitzungsnummer: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>Titel durch Shell festgelegt: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>Programmname: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>aktuelles Verzeichnis (kurz): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>aktuelles Verzeichnis (lang): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Im Dateimanager öffnen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Horizontal teilen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Vertikal teilen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Neuer Tab</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Vollbild beenden</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kodierung</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Benutzerdefinierte Befehle</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Fernverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Datei hochladen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Datei herunterladen </translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_el.ts
+++ b/translations/deepin-terminal_el.ts
@@ -4,63 +4,63 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Εντολή:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Συντομεύσεις:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="209"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="215"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Απαιτείται</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Προσθήκη Εντολής</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Επεξεργασία Εντολής</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Διαγραφή Εντολής</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="197"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Προσθήκη</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="199"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="636"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -78,22 +78,22 @@
         <translation type="vanished">Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="388"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="402"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="452"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Το όνομα υπάρχει ήδη,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="453"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>παρακαλώ εισάγετε άλλο κείμενο.</translation>
     </message>
@@ -105,15 +105,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Προσθήκη Εντολής</translation>
+    </message>
+    <message>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
+        <source>No commands yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="76"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Προσαρμοσμένες εντολές</translation>
     </message>
@@ -121,7 +126,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
@@ -129,53 +134,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="425"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="433"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Επιβεβαίωση</translation>
@@ -192,13 +197,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Διαγραφή διακομιστή</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Είστε βέβαιος ότι θέλετε να διαγράψετε %1;</translation>
     </message>
@@ -206,24 +211,24 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Νέο παράθυρο</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Κλείσιμο</translation>
@@ -237,7 +242,7 @@
         <translation type="vanished">Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2090"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -246,7 +251,7 @@
         <translation type="vanished">Επιλογή χώρου εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1808"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Πληκτρολογήστε διαδρομή για το αρχείο λήψης</translation>
     </message>
@@ -258,356 +263,371 @@
         <translation type="vanished">OK</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Αντιγραφή κατά την επιλογή:</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Αναβόσβημα δρομέα</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Στυλ δρομέα</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Κύλιση με πληκτρολόγηση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Κύλιση στην εκροή</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Απόκρυψη παραθύρου &quot;Quake&quot; μετά από την απώλεια εστίασης</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="148"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Θωλό παρασκήνιο</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Χρήση κατά την εκκίνηση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Γραμματοσειρά</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Μέγεθος γραμματοσειράς</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="171"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Αδιαφάνεια</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Προηγμένες</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Δρομέας</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Παράθυρο</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Βασικές</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Διεπαφή</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Συντομεύσεις</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1654"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Άλλα</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="37"/>
-        <location filename="../src/main/mainwindow.cpp" line="1652"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Τερματικό</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Χώρος εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Προσαρμοσμένες εντολές</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Προβολή συντομεύσεων</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Απομακρυσμένη διαχείριση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Μετονομασία τίτλου</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Πλήρης οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Προεπιλεγμένο μέγεθος</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Επικόλληση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Επιλογή όλων</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Μετάβαση στην επόμενη εντολή</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Μετάβαση στην προηγούμενη εντολή</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Μεγέθυνση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Σμίκρυνση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Κλείσιμο άλλων παραθύρων</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="493"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Κλείσιμο άλλων χώρων εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1153"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1159"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1161"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1207"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Κλείσιμο παράθυρου</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Κλείσιμο χώρου εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Οριζόντια διαίρεση</translation>
     </message>
@@ -640,14 +660,14 @@
         <translation type="vanished">Επιλογή ανώτερου παράθυρου</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Κάθετη διαίρεση</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Εύρεση</translation>
     </message>
@@ -660,52 +680,52 @@
         <translation type="vanished">Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="392"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="639"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="40"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1650"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1670"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1755"/>
-        <location filename="../src/common/utils.cpp" line="146"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Επιλογή αρχείου προς μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1762"/>
-        <location filename="../src/common/utils.cpp" line="151"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Εξακολουθούν να τρέχουν προγράμματα στο τερματικό</translation>
     </message>
@@ -718,55 +738,55 @@
         <translation type="vanished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="172"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Κλείσιμο τρέχοντος παραθύρου;</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1824"/>
-        <location filename="../src/common/utils.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Επιλέξτε φάκελο για αποθήκευση του αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Είστε σίγουροι ότι θέλετε να το απεγκαταστήσετε;</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Είστε σίγουροι ότι θέλετε να απεγκαταστήσετε αυτή την εφαρμογή;</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -775,57 +795,57 @@
         <translation type="vanished">Αντικατάσταση</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="330"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Τρέξτε μια εντολή στο τερματικό</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="333"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="324"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="327"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="395"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>To όνομα δεν πρέπει να είναι περισσότερο από 32 χαρακτήρες</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="578"/>
-        <location filename="../src/main/mainwindow.cpp" line="1830"/>
-        <location filename="../src/common/utils.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="574"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Επιλογή αρχείου ιδιωτικού κλειδιού</translation>
     </message>
@@ -838,41 +858,41 @@
         <translation type="vanished">Επιλογή χώρου εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="127"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="129"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Επιβεβαίωση</translation>
@@ -881,20 +901,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="179"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Προσθήκη Διακομιστή</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
+        <source>No servers yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Απομακρυσμένη διαχείριση</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -902,7 +927,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="223"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
@@ -910,95 +935,95 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="67"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Προηγμένες επιλογές</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="107"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Προσθήκη Διακομιστή</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Όνομα διακομιστή:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="147"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Απαιτείται</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Διεύθυνση:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="162"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Θύρα:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="183"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Όνομα χρήστη:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Κωδικός πρόσβασης:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Πιστοποιητικό:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Ομάδα:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Διαδρομή:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="234"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Εντολή:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="240"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Κωδικοποίηση:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Πλήκτρο Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Πλήκτρο Delete:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="274"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Διαγραφή διακομιστή</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="295"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="296"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Προσθήκη</translation>
@@ -1012,39 +1037,33 @@
         <translation type="vanished">Προσθήκη</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="300"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Επεξεργασία Διακομιστή</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="301"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="409"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="420"/>
-        <source>tty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Παρακαλούμε εισάγετε όνομα διακομιστή</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="515"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Παρακαλώ εισάγετε IP διεύθυνση </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Παρακαλούμε εισάγετε θύρα</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="526"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Παρακαλούμε εισάγετε όνομα χρήστη</translation>
     </message>
@@ -1053,36 +1072,12 @@
         <translation type="vanished">Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="405"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="417"/>
-        <source>ascii-del</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="406"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="418"/>
-        <source>auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="407"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="419"/>
-        <source>control-h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="408"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="416"/>
-        <source>escape-sequence</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="540"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Το όνομα του διακομιστή υπάρχει ήδη,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="541"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>παρακαλώ εισάγετε άλλο.</translation>
     </message>
@@ -1094,7 +1089,7 @@
         <translation type="vanished">OK</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="388"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -1103,38 +1098,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Πλήρης οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Κανονικό παράθυρο</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="285"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="294"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="301"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="308"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="314"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1153,55 +1158,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="56"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="105"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1228,34 +1233,34 @@
         <translation type="vanished">Μετονομασία τίτλου</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="459"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="462"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Επικόλληση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="471"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="475"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Άνοιγμα στη διαχείριση αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="484"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Οριζόντια διαίρεση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="487"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Κάθετη διαίρεση</translation>
     </message>
@@ -1272,58 +1277,58 @@
         <translation type="vanished">Νέος χώρος εργασίας</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="497"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Έξοδος από πλήρη οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="506"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Πλήρης οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="509"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Εύρεση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="513"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="523"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Κωδικοποίηση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="525"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Προσαρμοσμένες εντολές</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="527"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Απομακρυσμένη διαχείριση</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Μεταφόρτωση αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="532"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Λήψη αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
@@ -1343,21 +1348,21 @@
         <translation type="vanished">OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>

--- a/translations/deepin-terminal_en.ts
+++ b/translations/deepin-terminal_en.ts
@@ -226,7 +226,7 @@
         <location filename="../src/views/listview.cpp" line="289"/>
         <location filename="../src/views/listview.cpp" line="478"/>
         <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
-        <location filename="../src/common/utils.cpp" line="228"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
@@ -246,54 +246,54 @@
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="96"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Close workspace</translation>
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="507"/>
-        <location filename="../src/settings/settings_translation.cpp" line="92"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Close other workspaces</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1167"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Could not open &quot;%1&quot;, unable to run it</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1175"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Could not find &quot;%1&quot;, unable to run it</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1205"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="120"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Tab title format</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="122"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Remote tab title format</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
         <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="68"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Rename title</translation>
@@ -311,338 +311,343 @@
         <translation>Close other tabs</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="18"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copy on select</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="20"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Cursor blink</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="22"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Cursor style</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="24"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Scroll on keystroke</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="26"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Scroll on output</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="28"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Hide Quake window after losing focus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="30"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Quake window animation speed</source>
         <translation>Quake window animation speed</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="32"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Blur background</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="34"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Use on starting</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="36"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="38"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Font size</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="40"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacity</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="42"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="44"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="46"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Scroll</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="48"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Window</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="50"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Basic</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="52"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="54"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="56"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Others</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="58"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
         <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="60"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Workspace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="62"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Custom commands</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="64"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="66"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Remote management</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="70"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="72"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="74"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Default size</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="76"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="78"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="80"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="82"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Jump to next command</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="84"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Jump to previous command</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="86"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="88"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Zoom out</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="90"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Close other windows</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="94"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Close window</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="98"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Horizontal split</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="100"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>New tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="102"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Next tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="104"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Previous tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="106"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Select left workspace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="108"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Select lower workspace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="110"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Select right workspace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="112"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Select upper workspace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="114"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Vertical split</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Tab titles</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="124"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Go to tab 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="126"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Go to tab 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="128"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Go to tab 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="130"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Go to tab 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="132"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Go to tab 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="134"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Go to tab 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="136"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Go to tab 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="138"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Go to tab 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="140"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Go to tab 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="142"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Disable flow control using Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="144"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell profile</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="146"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>History size</source>
         <translation>History scrollback size</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
@@ -658,7 +663,7 @@
     <message>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
         <location filename="../src/main/mainwindow.cpp" line="1837"/>
-        <location filename="../src/common/utils.cpp" line="117"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
@@ -684,115 +689,115 @@
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1761"/>
-        <location filename="../src/common/utils.cpp" line="132"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Select file to upload</translation>
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1768"/>
-        <location filename="../src/common/utils.cpp" line="137"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1831"/>
-        <location filename="../src/common/utils.cpp" line="111"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Select a directory to save the file</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="397"/>
+        <location filename="../src/main/service.cpp" line="396"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>please set another one.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="157"/>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Close this terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="158"/>
-        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>There is still a process running in this terminal. Closing the terminal will kill it.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="162"/>
-        <location filename="../src/common/utils.cpp" line="196"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="167"/>
-        <location filename="../src/common/utils.cpp" line="187"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Close this window?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="168"/>
-        <location filename="../src/common/utils.cpp" line="188"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>There are still processes running in this window. Closing the window will kill all of them.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="205"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Programs are still running in terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="205"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Are you sure you want to uninstall it?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="218"/>
-        <location filename="../src/common/utils.cpp" line="222"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Are you sure you want to uninstall this application?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="219"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>You will not be able to use Terminal any longer.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
-        <location filename="../src/common/utils.cpp" line="273"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="307"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Set the work directory</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="310"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Set the window mode on starting</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="313"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Execute a command in the terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="316"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Run script string in the terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="319"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Run in quake mode</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="322"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Keep terminal open when command finishes</translation>
     </message>
@@ -972,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="393"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -981,32 +986,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normal window</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Split screen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="712"/>
+        <location filename="../src/settings/settings.cpp" line="718"/>
         <source>Fast</source>
         <translation>Fast</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="717"/>
+        <location filename="../src/settings/settings.cpp" line="723"/>
         <source>Slow</source>
         <translation>Slow</translation>
     </message>
@@ -1177,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="175"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="208"/>
-        <location filename="../src/common/utils.cpp" line="240"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_es.ts
+++ b/translations/deepin-terminal_es.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Atajo:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Requerido</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Añadir comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Editar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Borrar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Por favor introduzca un nombre</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Por favor introduzca un comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>El nombre ya existe,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>por favor ingrese otro.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Añadir comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Aun no hay comandos</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema personalizado</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Estilo:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Oscuro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Color principal:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Color de fondo:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Borrar servidor</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>¿Está seguro que quiere borrar %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nueva ventana</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Escriba la ruta para descargar el archivo</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema personalizado</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Cerrar espacio de trabajo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Cerrar los otros espacios de trabajo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>No se encontró &quot;%1&quot;, iniciando &quot;%2&quot; en su lugar. Por favor, verifique su perfil de shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>No se pudo abrir &quot;% 1&quot;, no se pudo ejecutar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>No se encontró &quot;%1&quot;, no se puede ejecutar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>La salida se ha suspendido presionando Ctrl + S. Presione Ctrl + Q para reanudar.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Formato de título de pestaña</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Formato de título de pestaña remota</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Renombrar título</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Cerrar las otras pestañas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copiar al seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Cursor con parpadeo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Estilo de cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Desplazamiento de tecla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Desplazamiento en la impresión</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Ocultar el modo Quake al cambiar de ventana</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Desenfoque del fondo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Iniciar con</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interfaz</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Atajos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Espacio de trabajo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Conexiones remotas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Tamaño por defecto</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Saltar al siguiente comando</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Saltar al comando anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Cerrar otras ventanas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Cerrar ventana</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>División horizontal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Pestaña siguiente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Pestaña anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Seleccionar espacio de trabajo de la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Seleccionar espacio de trabajo de abajo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Seleccionar espacio de trabajo de la derecha</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Seleccionar espacio de trabajo de arriba</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>División vertical</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Títulos de pestañas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ir a pestaña 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ir a pestaña 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ir a pestaña 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ir a pestaña 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ir a pestaña 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ir a pestaña 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ir a pestaña 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ir a pestaña 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ir a pestaña 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Desactivar el control de flujo usando Ctrl + S, Ctrl + Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Perfil de shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>El nombre no debe tener más de 32 caracteres.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Seleccione el archivo de clave privada</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal de Deepin es un emulador de terminal avanzado con espacios de trabajo, división de ventana, administración de conexiones remotas, modo Quake y otras características.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Pestañas</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Cambiar el enfoque al icono &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Seleccionar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Seleccionar archivo para subir</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Seleccione una carpeta para guardar el archivo</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>por favor establezca otro.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>¿Cerrar esta terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Aún hay un proceso ejecutándose en esta terminal. Cerrar la terminal lo matará.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Aún hay %1 procesos ejecutándose en esta terminal. Cerrar la terminal los matará.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>¿Cerrar esta ventana?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Aún hay procesos ejecutándose en esta ventana. Cerrar la ventana los matará a todos.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Aún hay programas ejecutándose en la terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>¿Está seguro que quiere desinstalarlo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>¿Está seguro que quiere desinstalar esta aplicación?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Ya no podrá usar Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Establecer carpeta de trabajo</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Establecer el modo de ventana al iniciar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Ejecutar un comando en la terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Ejecutar secuencia de comandos en la terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Ejecutar en modo Quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Mantener la terminal abierta cuando finalice el comando</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Añadir servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Aún no hay servidores</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Conexiones remotas</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Verifique que los comandos rz y sz estén instalados en el servidor antes de hacer clic derecho para cargar y descargar archivos.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opciones avanzadas</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Añadir servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nombre del servidor:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Requerido</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Dirección:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nombre de usuario:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Contraseña:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificado:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Carpeta de inicio:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Codificación:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tecla de retroceso:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Tecla suprimir:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Borrar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Editar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Por favor ingrese un nombre de servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Por favor ingrese una dirección IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Por favor ingrese un puerto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Por favor ingrese un nombre de usuario</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>El nombre del servidor ya existe,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>por favor ingrese otro.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Ventana normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Dividir ventana</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Ventana maximizada</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>El atajo %1 no es válido, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>El atajo %1 ya está en uso, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nombre de usuario: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nombre de usuario@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>host remoto: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>numero de sesión: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>título establecido por shell: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nombre de programa: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>carpeta actual (corto): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>carpeta actual (largo): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>host local: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Abrir en administrador de archivo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>División horizontal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>División vertical</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Salir de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Buscar en Internet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Conexiones remotas</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Subir archivo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Descargar archivo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>

--- a/translations/deepin-terminal_fi.ts
+++ b/translations/deepin-terminal_fi.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Komento:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Pikanäppäimet:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Vaadittu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Lisää komento</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Muokkaa komentoa</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Poista komento</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Kirjoita nimi</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Kirjoita komento</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Nimi on jo olemassa.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>kirjoita toinen.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Lisää komento</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Mukautetut komennot</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Mukautettu teema</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Tyyli:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Vaalea</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Tumma</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Etuosan väri:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Taustan väri:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Kehote PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Kehote PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Poista palvelin</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Haluatko varmasti poistaa %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Uusi ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Kirjoita ladattavan tiedoston polku</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Mukautettu teema</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Sulje välilehti</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Sulje muut työtilat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Ei lötynyt &quot;%1&quot;, alkaa sen sijaan &quot;%2&quot;. Tarkista liittymäsi profiili.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Tiedostoa &quot;%1&quot; ei voitu avata, eikä suorittaa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Ei löytynyt &quot;%1&quot;, suoritus epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Tulostus on keskeytetty yhdistelmällä Ctrl+S. Jatka painamalla Ctrl+Q.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Välilehden otsikon muoto</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Etävälilehden otsikon muoto</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Nimeä välilehti</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Sulje välilehti</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Sulje muut välilehdet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopioi valittu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Kursorin vilkkuminen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Kursorin tyyli</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Selaa näppäimillä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Selaa ulostuloa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Piilota quake-ikkuna kadotetun tarkennuksen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Sumea tausta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Käyttö käynnistettäessä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Kirjasin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Kirjasimen koko</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Läpinäkyvyys</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Lisäasetukset</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursori</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Vieritä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Perusasetukset</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Liitäntä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Pikanäppäimet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Muut</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Pääte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Välilehti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Mukautetut komennot</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Näytä pikanäppäimet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Etähallinta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Oletuskoko</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Siirry seuraavaan komentoon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Siirry edelliseen komentoon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Lähennä</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Loitonna</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Sulje paneelit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Sulje paneeli</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Vaakasuora jako</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Uusi välilehti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Seuraava välilehti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Edellinen välilehti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Valitse vasen työtila</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Valitse alempi työtila</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Valitse oikea työtila</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Valitse ylempi työtila</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Pystysuora jako</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Välilehden otsikot</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Välilehteen 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Välilehteen 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Välilehteen 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Välilehteen 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Välilehteen 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Välilehteen 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Välilehteen 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Välilehteen 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Välilehteen 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Poista vuonohjaus käytöstä Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Liittymän profiili</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Nimessä saa olla enintään 32 merkkiä</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Valitse yksityinen avaintiedosto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Valitse</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Pääte on edistynyt terminal-emulaattori, joka sisältää välilehdet, useita ikkunoita, etähallinan, Quake-tilan ja muita ominaisuuksia.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Välilehdet</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Vaihda kohdistus &quot;+&quot; kuvakkeeseen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Valitse välilehti</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Valitse lähetettävä tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Lähetä</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Valitse kansio, johon tiedosto tallennetaan</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>aseta toinen.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Sulje tämä pääte?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Tässä päätteessä on vielä prosessi käynnissä. Sulkeminen lopettaa sen.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Tässä päätteessä on vielä %1 prosessia käynnissä. Sulkeminen lopettaa ne.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Sulje tämä ikkuna?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Tässä ikkunassa on edelleen käynnissä prosesseja. Ikkunan sulkeminen tappaa ne kaikki.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Ohjelmia on silti käynnissä päätteessä</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Haluatko varmasti poistaa sen asennuksen?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Haluatko varmasti poistaa tämän sovelluksen asennuksen?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Et voi enää jatkaa päätteen käyttöä.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Aseta työhakemisto</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Ikkunatila käynnistyessä</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Suorita komento päätteessä</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Suorita komentosarja päätteessä</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Suorita quake-tilassa</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Pidä pääte auki, kun komento on valmis</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Lisää palvelin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Etähallinta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Varmista, että rz- ja sz-komennot on asennettu palvelimelle, ennen kuin napsautat hiiren oikealla painikkeella tiedostojen lähettämistä ja lataamista.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Lisäasetukset</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Lisää palvelin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Palvelimen nimi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Vaadittu</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Osoite:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Portti:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Käyttäjänimi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Salasana:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Sertifikaatti:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Ryhmä:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Polku:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Komento:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Koodaus:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Askelpalautin:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Delete-näppäin:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Poista palvelin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Muokkaa palvelinta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Kirjoita palvelimen nimi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Kirjoita IP-osoite</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Anna portti</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Kirjoita käyttäjänimi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Palvelimen nimi on jo olemassa,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>kirjoita toinen.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normaali ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Jaettu näyttö</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Kokoruutu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Pikakuvake %1 ei kelpaa,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Pikakuvake %1 on jo käytössä,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>käyttäjänimi: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>käyttäjänimi@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>etäpalvelin: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>istunnon numero: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>shell asettanut otsikon: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>ohjelman nimi: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>nykyinen hakemisto (lyhyt): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>nykyinen hakemisto (pitkä): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>paikallinen palvelin: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Avaa tiedostonhallinnassa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Vaakasuora jako</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Pystysuora jako</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Uusi välilehti</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Poistu koko näytöstä</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Koodaus</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Mukautetut komennot</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Etähallinta</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Lähetä tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Lataa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_fr.ts
+++ b/translations/deepin-terminal_fr.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Commande :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Raccourcis :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Requis</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Insérer une commande</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Éditer la commande</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Supprimer la commande</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Veuillez saisir un nom</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Veuillez saisir une commande</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Le nom existe déjà,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>veuillez en saisir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Insérer une commande</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Commandes personnalisées</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Thème personnalisé</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Style :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Clair</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Sombre</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Couleur de premier plan :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Couleur de fond :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Invite PS1 :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Invite PS2 :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Supprimer le serveur</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Voulez-vous vraiment supprimer %1 ?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nouvelle fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Taper le chemin pour télécharger le fichier</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Thème personnalisé</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Fermer l&apos;espace de travail</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Fermer les autres espaces de travail</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Impossible de trouver &quot;%1&quot;, démarrage de &quot;%2&quot; à la place. Veuillez vérifier votre profil shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>L&apos;ouverture de &quot;%1&quot; a échouée, impossible de l&apos;exécuter</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Impossible de trouver &quot;%1&quot;, impossible de l&apos;exécuter</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>La sortie a été suspendue en appuyant sur Ctrl+S. Appuyez sur Ctrl+Q pour reprendre.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format du titre de l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format du titre de l&apos;onglet distant</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Renommer le titre</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Fermer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Fermer les autres onglets</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copier la sélection</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Clignotement du curseur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Style de curseur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Défilement sur pression d&apos;une touche</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Faire défiler les résultats</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Cacher la fenêtre Quake après avoir perdu le focus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Flou Arrière-plan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Utiliser au démarrage</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Police</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Taille de police</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacité</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Curseur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Défiler</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>De base</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Espace de travail</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Commandes personnalisées</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Contrôle à distance</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Taille par défaut</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Commande suivante</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Commande précédente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Fermer les autres fenêtres</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Fermer la fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Diviser horizontalement</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nouvel onglet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Onglet suivant</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Onglet précédent</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Sélectionner l&apos;espace de travail de gauche</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Sélectionner l&apos;espace de travail inférieur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Sélectionner l&apos;espace de travail de droite</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Sélectionner l&apos;espace de travail supérieur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Diviser verticalement</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Titres des onglets</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Aller à l&apos;onglet 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Aller à l&apos;onglet 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Aller à l&apos;onglet 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Aller à l&apos;onglet 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Aller à l&apos;onglet 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Aller à l&apos;onglet 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Aller à l&apos;onglet 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Aller à l&apos;onglet 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Aller à l&apos;onglet 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Désactiver le contrôle de flux à l&apos;aide de Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil Shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Le nom ne doit pas dépasser 32 caractères</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Sélectionner le fichier de clé privée</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal est un émulateur de terminal avancé avec espace de travail, fenêtres multiples, gestion à distance, un mode &quot;Quake&quot; et d&apos;autres fonctionnalités.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Onglets</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Basculez le focus avec l&apos;icône &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Sélectionner l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Sélectionner le fichier à transférer</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Transférer</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Sélectionnez un répertoire pour enregistrer le fichier</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>veuillez en définir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Fermer ce terminal ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Un processus est toujours en cours d&apos;exécution dans ce terminal. La fermeture du terminal le tuera.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Il reste %1 processus en cours d&apos;exécution dans ce terminal. La fermeture du terminal les tuera tous.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Fermer cette fenêtre ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Il y a encore des processus en cours d&apos;exécution dans cette fenêtre. Fermer la fenêtre les tuera tous.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Des programmes sont toujours en cours d&apos;exécution dans le terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Êtes-vous sûr de vouloir le désinstaller ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Êtes-vous sûr de vouloir désinstaller cette application ?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Vous ne pourrez plus utiliser le Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Définir le répertoire de travail</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Définir le mode de fenêtre au démarrage</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Exécuter une commande dans le terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Exécuter la chaîne de script dans le terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Exécuter en mode tremblement</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Garder le terminal ouvert lorsque la commande se termine</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Ajouter un serveur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Contrôle à distance</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Assurez-vous que les commandes rz et sz ont été installées sur le serveur avant de cliquer avec le bouton droit pour envoyer et télécharger des fichiers.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Options avancées</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Ajouter un serveur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nom du serveur :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Requis</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresse :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nom d&apos;utilisateur :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Mot de passe :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificat :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Groupe :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Chemin : </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Commande :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Encodage :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Touche retour arrière :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Supprimer la clé :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Supprimer le serveur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Éditer le serveur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Veuillez saisir un nom de serveur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Veuillez saisir une adresse IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Veuillez entrer un port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Merci d&apos;entrer un nom d&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Le nom du serveur existe déjà,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>veuillez en saisir un autre.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Fenêtre normale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Écran divisé</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Le raccourci %1 n&apos;est pas valide,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Le raccourci %1 était déjà utilisé,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nom d&apos;utilisateur : %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nom d&apos;utilisateur@ : %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>hôte distant : %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>numéro de session : %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>titre défini par le shell : %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nom du programme : %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>répertoire actuel (court) : %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>répertoire actuel (long) : %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>hôte local : %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Ouvrir dans le gestionnaire de fichier</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Diviser horizontalement</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Diviser verticalement</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nouvel onglet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Quitter le plein écran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Trouver</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Commandes personnalisées</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Contrôle à distance</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Transférer un fichier</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Télécharger un fichier</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_gl_ES.ts
+++ b/translations/deepin-terminal_gl_ES.ts
@@ -4,63 +4,63 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Atallos:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="209"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="215"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Requirido</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Engadir Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Editar Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Eliminar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="197"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Engadir</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="199"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Gardar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="636"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Aceptar</translation>
@@ -78,22 +78,22 @@
         <translation type="vanished">Gardar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="388"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Insira un nome</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="402"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Insira un comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="452"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>O nome xa existe,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="453"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>por favor, poña outro.</translation>
     </message>
@@ -105,15 +105,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Engadir Comando</translation>
+    </message>
+    <message>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
+        <source>No commands yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="76"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
@@ -121,7 +126,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -129,53 +134,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="425"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="433"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirmar</translation>
@@ -199,13 +204,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Eliminar servidor</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Estás seguro de que queres eliminar %1?</translation>
     </message>
@@ -213,24 +218,24 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nova xanela</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Axustes</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Pechar</translation>
@@ -244,12 +249,12 @@
         <translation type="vanished">Pechar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1808"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Tipo de ruta para descargar o ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2090"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -261,368 +266,383 @@
         <translation type="vanished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copiar ao seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Intermitencia do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Estilo do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Desprazar cunha pulsación de tecla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Desprazar a saída</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Agochar a xanela Quake despois de perder o foco</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="148"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Fondo desenfocado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Usar ao principio</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Tamaño da fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="171"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacidade</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Desprazar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Xanela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Atallos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1654"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="37"/>
-        <location filename="../src/main/mainwindow.cpp" line="1652"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Área de traballo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Amosar atallos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Xestión remota</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Renomear título</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Tamaño predefinido</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Ir ao comando seguinte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Ir ao comando anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Achegar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Afastar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Pechar outras xanelas</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="493"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Pechar outros espazos de traballo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1153"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1159"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1161"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1207"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Pechar a xanela</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Pechar o espazo de traballo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>División horizontal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>División vertical</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Atopar</translation>
     </message>
@@ -635,52 +655,52 @@
         <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="392"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="639"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>por favor, estableza outro</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="40"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>O terminal é un emulador de termos avanzado con espazo de traballo, múltiples xanelas, xestión remota, modo de terremoto e outras funcións.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1650"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1670"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1755"/>
-        <location filename="../src/common/utils.cpp" line="146"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Seleccionar ficheiro a subir</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1762"/>
-        <location filename="../src/common/utils.cpp" line="151"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Aínda hai programas en execución no terminal</translation>
     </message>
@@ -693,55 +713,55 @@
         <translation type="vanished">Saír</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Pechar este terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="172"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Aínda hai un proceso en execución neste terminal. O peche do terminal matalo.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Aínda hai procesos %1 executados neste terminal. O peche do terminal matará a todos eles.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Pechar esta xanela?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Aínda hai procesos en execución nesta xanela. O peche da xanela matará a todos.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1824"/>
-        <location filename="../src/common/utils.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Seleccione un directorio para gardar o ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Estás seguro de que queres desinstalalo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Estás seguro de que queres desinstalar este aplicativo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Xa non poderás usar Terminal.</translation>
     </message>
@@ -754,57 +774,57 @@
         <translation type="vanished">Substituír</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="330"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Executa un comando no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="333"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Executa a cadea de guión no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="324"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Estableza o directorio de traballo</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="327"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Estableza o modo da xanela ao comezo</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Executa en modo terremoto</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Manteña o terminal aberto cando termine o comando</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="395"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>O nome non debe ser superior a 32 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="578"/>
-        <location filename="../src/main/mainwindow.cpp" line="1830"/>
-        <location filename="../src/common/utils.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="574"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Seleccionar o ficheiro de clave privada</translation>
     </message>
@@ -813,41 +833,41 @@
         <translation type="vanished">Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="127"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="129"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirmar</translation>
@@ -856,20 +876,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="179"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Engadir Servidor</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
+        <source>No servers yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Xestión remota</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Asegúrese de que se instalaron as ordes rz e sz no servidor antes de facer clic dereito para cargar e descargar ficheiros.</translation>
     </message>
@@ -877,7 +902,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="223"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -885,95 +910,95 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="67"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opcións avanzadas</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="107"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Engadir Servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nome de servidor:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="147"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Requirido</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Enderezo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="162"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porto:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="183"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nome de usuario:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Contrasinal:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificado:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="234"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="240"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Codificación:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tecla retroceso:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Eliminar chave:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="274"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Eliminar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="295"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="296"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Engadir</translation>
@@ -987,39 +1012,37 @@
         <translation type="vanished">Engadir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="300"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Editar Servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="301"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Gardar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="409"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="420"/>
         <source>tty</source>
-        <translation>tty</translation>
+        <translation type="vanished">tty</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Insira o nome do servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="515"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Insira un enderezo IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Insira un porto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="526"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Insira un nome de usuario</translation>
     </message>
@@ -1028,36 +1051,28 @@
         <translation type="vanished">Gardar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="405"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="417"/>
         <source>ascii-del</source>
-        <translation>ascii-del</translation>
+        <translation type="vanished">ascii-del</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="406"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="418"/>
         <source>auto</source>
-        <translation>automático</translation>
+        <translation type="vanished">automático</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="407"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="419"/>
         <source>control-h</source>
-        <translation>control-h</translation>
+        <translation type="vanished">control-h</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="408"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="416"/>
         <source>escape-sequence</source>
-        <translation>secuencia de escape</translation>
+        <translation type="vanished">secuencia de escape</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="540"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>O nome do servidor xa existe,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="541"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>por favor, poña outro.</translation>
     </message>
@@ -1069,7 +1084,7 @@
         <translation type="vanished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="388"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Aceptar</translation>
@@ -1078,38 +1093,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Dividir a pantalla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Xanela normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Máximo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="285"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="294"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>O atallo %1 é inválido,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="301"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="308"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="314"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>O atallo %1 estivo xa en uso,</translation>
     </message>
@@ -1117,55 +1142,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="56"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="105"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1184,90 +1209,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="459"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="462"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="471"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="475"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Abrir no xestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="484"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>División horizontal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="487"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>División vertical</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="497"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Saír da pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="506"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="509"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Atopar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="513"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="523"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="525"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="527"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Xestión remota</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Subir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="532"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Descargar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Axustes</translation>
     </message>
@@ -1287,21 +1312,21 @@
         <translation type="vanished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Pechar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">Aceptar</translation>

--- a/translations/deepin-terminal_hi_IN.ts
+++ b/translations/deepin-terminal_hi_IN.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hi_IN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>नाम :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>कमांड :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>शॉर्टकट :</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>आवश्यक</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>कमांड जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>कमांड संपादन</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>कमांड हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>कृपया नाम दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>कृपया कमांड दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>नाम पहले से प्रयुक्त है,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>कृपया अन्य दर्ज करें।</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक है</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>कमांड जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>अनुकूलित कमांड</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>खोजें</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>अनुकूलित थीम</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>शैली :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>हल्का </translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>गहरा</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>फोरग्राउंड रंग :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>बैकग्राउंड रंग :</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>सूचक PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>सूचक PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>पुष्टि करें</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>सर्वर हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>क्या आप स्पष्ट होकर %1 को हटाना चाहते हैं ?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>नवीन विंडो</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>फाइल डाउनलोड हेतु पथ दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>अनुकूलित थीम</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>पुष्टि करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>कार्यस्थल बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>अन्य कार्यस्थल बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>&quot;%1&quot; की प्राप्ति विफल होने के कारण उसके स्थान पर &quot;%2&quot; आरंभ होगा। कृपया अपना शैल प्रोफाइल देखें।</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; को खोलना विफल होने के कारण उसे निष्पादित करना संभव नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; की प्राप्ति विफल होने के कारण उसे निष्पादित करना संभव नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Ctrl+S कुंजी संयोजन दबाने के कारण आउटपुट स्थगित किया गया। पुनः जारी रखने हेतु Ctrl+Q दबाएँ।</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>टैब शीर्षक प्रारूप</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>दूरस्थ टैब शीर्षक प्रारूप</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>शीर्षक बदलें</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>अन्य टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>चयन होने पर कॉपी करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>निमिष कर्सर</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>कर्सर शैली</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>कुंजीपटल द्वारा स्क्रॉल</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>आउटपुट स्क्रॉल करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>उपयोक्ता द्वारा विंडो उपयोग न होने पर Quake विंडो अदृश्य करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>बैकग्राउंड हेतु धुंध प्रभाव</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>आरंभ होने पर उपयोग करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>मुद्रलिपि</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>मुद्रलिपि आकार</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>अपारदर्शिता</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>विस्तृत</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>कर्सर </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>विंडो</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>सामान्य</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>अंतरफलक</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>शॉर्टकट</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>अन्य</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>टर्मिनल</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>कार्यस्थल</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>अनुकूलित कमांड</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>शॉर्टकट दिखाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>दूरस्थ प्रबंधन</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>कॉपी करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>डिफ़ॉल्ट आकार</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>पेस्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>खोजें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>सभी चयनित करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>अगली कमांड पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>पिछली कमांड पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>आकार बढ़ाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>आकार घटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>अन्य विंडो बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>विंडो बंद करें </translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>क्षैतिज विभाजन</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>नवीन टैब</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>अगला टैब</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>पिछला टैब</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>बायां कार्यस्थल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>निचला कार्यस्थल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>दायां कार्यस्थल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>ऊपरी कार्यस्थल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>लंबवत विभाजन</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>खोज</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>टैब शीर्षक</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>टैब 1 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>टैब 2 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>टैब 3 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>टैब 4 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>टैब 5 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>टैब 6 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>टैब 7 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>टैब 8 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>टैब 9 पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+S, Ctrl+Q का उपयोग कर आउटपुट प्रवाह निष्क्रिय करें</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>शैल प्रोफाइल</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>नाम में 32 से अधिक अक्षर नहीं होने चाहिए</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>निजी कुंजी की फाइल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>टर्मिनल - कार्यस्थल, एकाधिक विंडो, दूरस्थ प्रबंधन, मोड व अन्य सुविधाओं युक्त एक सशक्त टर्मिनल अनुकरण प्रोग्राम है।</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>टैब</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>&quot;+&quot; आइकन पर केंद्रित करें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>टैब चुनें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>अपलोड हेतु फाइल चुनें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>फाइल संचय हेतु डायरेक्टरी चुनें</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>कृपया अन्य सेट करें।</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>यह टर्मिनल बंद करें?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>इस टर्मिनल पर अभी एक प्रक्रिया कार्यरत है। टर्मिनल बंद करने से वह प्रक्रिया समाप्त हो जाएगी।</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>इस टर्मिनल पर अभी %1 प्रक्रियाएँ कार्यरत हैं। टर्मिनल बंद करने से वे सभी प्रक्रियाएँ समाप्त हो जाएँगी।</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>यह विंडो बंद करें?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>इस विंडो पर अभी प्रक्रियाएँ कार्यरत हैं। विंडो बंद करने से वे सभी प्रक्रियाएँ समाप्त हो जाएँगी।</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>टर्मिनल में अभी भी प्रोग्राम कार्यरत हैं</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>क्या आप निश्चित ही इसे हटाना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>क्या आप निश्चित यह अनुप्रयोग हटाना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>अब आप टर्मिनल उपयोग नहीं कर सकेंगें।</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>कार्य डायरेक्टरी सेट करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>आरंभ होने पर विंडो मोड सेट करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>टर्मिनल में कमांड निष्पादित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>स्क्रिप्ट वाक्यांश टर्मिनल में निष्पादित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Quake मोड में निष्पादित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>कमांड पूर्ण होने तक टर्मिनल खुला रखें</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>सर्वर जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>दूरस्थ प्रबंधन</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>दाएँ क्लिक द्वारा फाइलें अपलोड व डाउनलोड करने से पहले सुनिश्चित करें कि rz एवं sz कमांड सर्वर पर इंस्टॉल हैं।</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>खोजें</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>विस्तृत विकल्प</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>सर्वर जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>सर्वर नाम :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>आवश्यक</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>पता :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>पोर्ट :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>उपयोक्ता नाम :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>कूटशब्द :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>प्रमाणपत्र :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>समूह :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>पथ :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>कमांड :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>एन्कोडिंग :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>बैकस्पेस कुंजी :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>कुंजी हटाएँ :</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>सर्वर डिलीट करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>सर्वर संपादन</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>कृपया सर्वर नाम दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>कृपया आईपी पता दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>कृपया पोर्ट दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>कृपया उपयोक्ता नाम दर्ज करें</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>सर्वर नाम पहले से प्रयुक्त है,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>कृपया अन्य दर्ज करें।</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक है</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>सामान्य विंडो</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>स्क्रीन विभाजन</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>अधिकतम</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>पूर्ण स्क्रीन</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>शॉर्टकट %1 अमान्य है,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>शॉर्टकट %1 पहले से प्रयुक्त है,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>प्रविष्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>उपयोक्ता नाम : %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>उपयोक्ता नाम @: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>दूरस्थ होस्ट : %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>सत्र संख्या : %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>शैल द्वारा सेट शीर्षक : %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>प्रोग्राम नाम : %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>वर्तमान डायरेक्टरी (लघु): &amp;d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>वर्तमान डायरेक्टरी (दीर्घ): &amp;d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>लोकल होस्ट : %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>कॉपी करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>पेस्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>फाइल प्रबंधक में खोलें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>क्षैतिज विभाजन</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>लंबवत विभाजन</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>नवीन टैब</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>पूर्ण स्क्रीन बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>खोज</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>खोजें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>एन्कोडिंग</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>अनुकूलित कमांड</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>दूरस्थ प्रबंधन</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>फाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>फाइल डाउनलोड करें</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक है</translation>

--- a/translations/deepin-terminal_hr.ts
+++ b/translations/deepin-terminal_hr.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Naredba:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Prečaci:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Potrebno</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Dodaj naredbu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Uredi naredbu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Obriši naredbu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Spremi</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Molim unesite ime</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Molim unesite naredbu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Ime već postoji,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>molim unesite neko drugo.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Dodaj naredbu</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Prilagođene naredbe</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Prilagođena tema</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stil:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Svijetlo</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Tamno</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Prednja boja:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Stražnja boja:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdi</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Obriši poslužitelj</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Jeste li sigurni da želite obrisati %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Novi prozor</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zatvori</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Ukucajte putanju za preuzimanje datoteke</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Prilagođena tema</translation>
     </message>
@@ -221,600 +223,615 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Obriši</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Zatvori radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Zatvore ostale radne prostore</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Preimenuj naslov</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Zatvori karticu</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopiraj pri odabiru</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Treptanje pokazivača</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Stil pokazivača</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Zamuti pozadinu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Veličina fonta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Neprozirnost</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Napredno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Pokazivač</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Kliži</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Prozor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Osnovno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Sučelje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Prečaci</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Ostalo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Prilagođene naredbe</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Prikaži prečace</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Udaljeno upravljanje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Zadana veličina</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Zalijepi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Odaberi sve</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Skoči na slijedeću naredbu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Skoči na prethodnu naredbu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Povećaj</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Smanji</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Zatvori ostale prozore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Zatvori prozor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Vodoravna podjela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nova kartica</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Slijedeća kartica</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Prethodna kartica</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Odaberi lijevi radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Odaberi donji radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Odaberi desni radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Odaberi gornji radni prostor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Okomita podjela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Naslovi kartice</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Idi na karticu 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Idi na karticu 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Idi na karticu 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Idi na karticu 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Idi na karticu 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Idi na karticu 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Idi na karticu 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Idi na karticu 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Idi na karticu 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Odaberi</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>KArtice</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Odaberi karticu</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Odaberite datoteku za slanje</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Slanje</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Odaberite direktorij za spremanje datoteke</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Zatvoriti ovaj terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Zatvoriti ovaj prozor?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Programi još rade u terminalu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Jeste li sigurni da želite deinstalirati?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Jeste li sigurni da želite deinstalirati ovu aplikaciju?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Ne možete više koristiti Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Postavi radni direktorij</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Izvrši naredbu u terminalu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Dodaj poslužitelj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Udaljeno upravljanje</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Napredne opcije</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Dodaj poslužitelj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Ime poslužitelja:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Potrebno</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresa:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port: </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Korisničko ime:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Lozinka:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certifikat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupa:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Putanja:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Naredba:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodiranje:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Backspace tipka:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Obriši tipku:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Obriši poslužitelj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Uredi poslužitelj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Spremi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Molim unesite ime poslužitelja</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Molim unesite IP adresu</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Molim unesite port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Molim unesite korisničko ime</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Ime poslužitelja već postoji.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>molim unesite neko drugo.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normalni prozor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Razdjeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Cijeli zaslon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Prečac %1 je neispravan,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Prečac %1 je već u uporabi,</translation>
     </message>
@@ -1008,146 +1035,146 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Umetni</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>korisničko ime: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>korisničko ime: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Zalijepi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Otvori</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Otvori u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Vodoravna podjela</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Okomita podjela</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nova kartica</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Izađi iz cijelog zaslona</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Enkodiranje</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Prilagođene naredbe</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Udaljeno upravljanje</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Slanje datoteke</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Preuzmi datoteku</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zatvori</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>

--- a/translations/deepin-terminal_hu.ts
+++ b/translations/deepin-terminal_hu.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Név:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Parancs:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Gyorsbillentyűk:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Kötelező</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Parancs hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Parancs szerkesztése</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Parancs törlése</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hozzáadás</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Kérjük adjon meg egy nevet</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Kérjük adjon meg egy parancsot</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Ez a név már létezik</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>Kérjük adjon meg egy másikat</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Parancs hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Még nincs parancs</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Egyéni parancsok</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Egyéni Téma</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stílus:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Világos</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Sötét</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Elülső szín:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Háttér szín:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Felszólítás PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Felszólítás PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Szerver törlése</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Biztos, hogy törölni akarja a %1-t?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Új ablak</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Elérési útvonal a letöltött fájlokhoz</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Egyéni téma</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Munkaterület bezárása </translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Egyéb munkaterületek bezárása</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Nem található a  &quot;%1&quot;, helyette a &quot;%2&quot; indul. Kérjük ellenőrizze a shell profilját.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Nem nyitható meg a &quot;%1&quot;, nem tudja futtatni azt</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Nem található a &quot;%1&quot;, nem tudja futtatni azt</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>A kimenet a Ctrl+S billentyűkombináció megnyomásával felfüggesztésre kerül. A folytatáshoz nyomja meg a Ctrl+Q billentyűkombinációt.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Fül címének formátuma</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Távoli fül címének formátuma</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Cím átnevezése</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Fül bezárása</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Egyéb fülek bezárása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Másolás kijelöléskor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Kurzor villogás</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Kurzor stílusa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Görgetés gombnyomásra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Görgetés kimenetnél</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Lebegő ablak elrejtése fókusz elvesztésekor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Háttér elhomályosítása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Használja indításkor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Betűtípus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Betűméret</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Áttetszőség</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Haladó</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kurzor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Görgetés</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Ablak</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Alapvető</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Felület</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Gyorsbillentyűk</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Egyebek</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminál</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Munkaterület</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Egyéni parancsok</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Gyorsbillentyűk megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Távoli elérés</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Alapértelmezett méret</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Ugrás a következő parancsra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Visszaugrás az előző parancsra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Nagyítás</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Kicsinyítés</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Egyéb ablakok bezárása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Ablak bezárása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Kettéosztás vízszintesen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Új fül</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Következő fül</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Előző fül</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Baloldali munkaterület kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Alsó munkaterület kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Jobboldali munkaterület kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Felső munkaterület kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Függőleges elválasztás</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Fülek címei</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ugrás az 1. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ugrás az 2. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ugrás az 3. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ugrás az 4. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ugrás az 5. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ugrás az 6. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ugrás az 7. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ugrás az 8. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ugrás az 9. fülre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>A folyam vezérlése a Ctrl+S, Ctrl+Q billentyűkombinációkkal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell profil</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>A név legfeljebb 32 karakter lehet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Privát kulcs fájl kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Kiválasztás</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>A Terminál egy fejlett terminálemulátor munkaterülettel, több ablakkal, távkezeléssel, lebegő móddal és egyéb funkciókkal.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Fülek</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Váltson fókuszt a „+” ikonnal</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Fül kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>A feltöltendő fájl kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Feltöltés</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Válasszon könyvtárat a fájl mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>Kérjük állítson be egy másikat.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Bezárja ezt a terminált?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Ebben a terminálban még fut egy folyamat. A terminál bezárása kilövi azt.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Még mindig fut a %1 folyamat ebben a terminálban. A terminál bezárása mindegyiket kilövi.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Bezárja ezt az ablakot?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Ebben az ablakban még fut egy folyamat. Az ablak bezárása kilövi valamennyit.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Még futnak programok a terminál ablakban</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Biztosan el szeretné távolítani?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Biztosan el szeretné távolítani ezt az alkalmazást?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Nem használhatja tovább a terminált.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Állítsa be a munkakönyvtár helyét</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Ablakmód indítási beállítása </translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Parancs futtatása terminál ablakban</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Szkript futtatása terminál ablakban</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Futtatás lebegő módban</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>A parancs befejezése után tartsa nyitva a terminál ablakot</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Szerver hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Még nincs szerver</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Távoli elérés</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Mielőtt a fájlok feltöltéséhez és letöltéséhez jobb gombbal kattintana, győződjön meg arról, hogy az rz és sz parancsok telepítve vannak a szerveren.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Haladó beállítások</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Szerver hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Szerver név:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Kötelező</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Cím:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Felhasználónév:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Jelszó:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Tanúsítvány:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Csoport:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Elérési útvonal:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Parancs:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kódolás:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Backspace billentyű:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Törlés billentyű:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Szerver törlése</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hozzáadás</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Szerver szerkesztése</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Kérjük adjon meg egy szerver nevet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Kérjük adjon meg egy IP címet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Kérjük adjon meg egy portot</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Kérjük adjon meg egy felhasználónevet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>A szerver név már használatban van</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>Kérjük adjon meg egy másikat</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normál ablak</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Osztott képernyő</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>A %1 gyorsbillentyű érvénytelen, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>A %1 gyorsbillentyű már használatban van, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>Felhasználónév: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>Felhasználónév@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>Távoli gazdagép: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>Munkamenet száma: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>Shell által beállított cím: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>Program neve: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>Jelenlegi mappa (rövid): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>Jelenlegi mappa (hosszú): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>Helyi gazdagép: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Megnyitás a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Vízszintes felosztás</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Függőleges felosztás</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Új fül</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Kilépés a teljes képernyőből</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kódolás</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Egyéni parancsok</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Távoli elérés</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Fájl feltöltése</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Fájl letöltése</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_id.ts
+++ b/translations/deepin-terminal_id.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="id">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Perintah:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Pintasan:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Dibutuhkan</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Tambah perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Ubah perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Hapus Perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Masukkan nama</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Masukkan perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Nama telah tersedia,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>gunakan kata lainnya.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Tambah perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Perintah kustom</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema Kustom</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Gaya:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Terang</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Gelap</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Warna depan:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Warna belakang:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Konfirmasi</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Hapus Peladen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Anda yakin ingin menghapus %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Jendela baru</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Ketik jalur untuk berkas unduhan</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema Kustom</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Tutup ruang kerja</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Tutup ruang kerja lainnya</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Tidak dapat menemukan &quot;%1&quot;, dimulai  &quot;%2&quot; sebagai gantinya. Silakan periksa profil shell Anda.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Tidak dapat membuka &quot;%1&quot;, tidak dapat menjalankannya</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Tidak dapat menemukan &quot;%1&quot;, tidak dapat menjalankannya</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Output telah ditangguhkan dengan menekan Ctrl + S. Menekan Ctrl + Q untuk melanjutkan.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format judul tab</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format judul tab jarak jauh</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Ubah judul</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Tutup Tab</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Tutup Tab lainnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Salin saat pilih</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Kedip Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Gaya kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Gulung ke keystroke</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Gulung pada keluaran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Sembunyikan jendela Quake setelah hilang fokus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Latar belakang buram</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Gunakan saat mulai</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fonta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Ukuran fonta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacity</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Gulung</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Jendela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Dasar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Antarmuka</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Pintasan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Lainnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Ruang kerja</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Perintah sesuaian</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Tampilkan pintasan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Manajemen jarak jauh</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Layar Penuh</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Ukuran bawaan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Tempel</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Loncat ke perintah berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Loncat ke perintah sebelumnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Perbesar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Perkecil</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Tutup jendela lainnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Tutup jendela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Bagi horizontal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Tab baru</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Tab berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Tab sebelumnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Pilih ruang kerja kiri</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Pilih ruang kerja bawah</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Pilih ruang kerja kanan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Pilih ruang kerja atas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Bagi vertikal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Temukan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Judul Tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Menuju Tab 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Menuju Tab 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Menuju Tab 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Menuju Tab 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Menuju Tab 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Menuju Tab 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Menuju Tab 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Menuju Tab 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Menuju Tab 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Nonaktifkan kontrol aliran menggunakan Ctrl + S, Ctrl + Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Nama tidak boleh lebih dari 32 karakter</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Pilih berkas kunci pribadi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Pilih</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal adalah emulator terminal tingkat lanjut dengan ruang kerja, banyak jendela, manajemen jarak jauh, mode bergoyang, dan fitur lainnya.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Alihkan fokus ke ikon &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Pilih Tab</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Pilih berkas untuk diunggah</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Unggah</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Pilih direktori untuk menyimpan berkas</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>Silakan setel yang lainnya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Tutup terminal ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Masih ada proses yang berjalan di terminal ini. Menutup terminal akan mematikannya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Masih ada %1 proses yang berjalan di terminal ini. Menutup terminal akan mematikan semuanya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Tutup jendela ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Masih ada proses yang berjalan di jendela ini. Menutup jendela akan mematikan semuanya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Program masih berjalan dalam terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Anda yakin ingin menghapusnya?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Apakah Anda yakin ingin menghapus aplikasi ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Anda tidak akan dapat menggunakan Terminal lagi.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Setel direktori kerja</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Atur mode jendela ketika memulai</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Eksekusi perintah di terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Jalankan skrip di terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Jalankan dalam mode goyang</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Biarkan terminal tetap terbuka saat perintah selesai</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Tambah Peladen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Manajemen jarak jauh</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Pastikan bahwa perintah rz dan sz telah dipasang di peladen sebelum mengklik kanan untuk mengunggah dan mengunduh berkas.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opsi lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Tambah Peladen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nama peladen:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Dibutuhkan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Alamat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nama pengguna:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Kata sandi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Sertifikat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Jalur:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Perintah:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Menyandi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Kunci Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Hapus kunci:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Hapus peladen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Ubah peladen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Masukkan nama peladen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Masukan alamat IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Masukkan porta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Masukkan nama pengguna</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Nama peladen telah ada,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>silakan gunakan yang lain.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Jendela normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Pisahkan layar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Layar Penuh</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Pemintas %1 tidak valid</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Pemintas %1 telah digunakan.</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Sisip</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nama pengguna: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nama pengguna@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>hos jarak jauh: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>nomor sesi: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>setel judul oleh terminal: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nama program: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>direktori saat ini (pendek): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>direktori saat ini (panjang): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>hos lokal: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Tempel</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Buka pada manajer berkas</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Bagi horizontal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Bagi vertikal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Tab baru</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Keluar layar penuh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Layar Penuh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Temukan</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Menyandi</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Perintah sesuaian</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Manajemen jarak jauh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Unggah berkas</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Unduh berkas</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_it.ts
+++ b/translations/deepin-terminal_it.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Scorciatoie:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Richiesta</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Aggiungi Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Modifica Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Elimina comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Inserisci un nome</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Inserisci un comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Il nome esiste già, </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>inseriscine un altro.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Aggiungi Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Nessun comando</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandi personalizzati</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema personalizzato</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stile:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Chiara</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Scura</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Colore anteriore:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Colore posteriore:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Elimina Server</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Sicuro di voler eliminare %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nuova finestra</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Digita il percorso per scaricare i file</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema personalizzato</translation>
     </message>
@@ -221,567 +223,582 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Chiudi spazio di lavoro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Chiudi altri spazi di lavoro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Impossibile trovare &quot;%1&quot;, inizia da &quot;%2&quot;. Controlla il tuo profilo Shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Impossibile aprire ed eseguire &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Impossibile trovare &quot;%1&quot;, non è possibile eseguirlo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>L&apos;output è stato sospeso con Ctrl+S. Premi Ctrl+Q per riprendere.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Formato titolo scheda</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Formato titolo della scheda remota</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Titolo rinominato</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Chiudi scheda</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Chiudi le altre schede</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copia sulla selezione</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Intermittenza cursore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Stile cursore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Scorri automaticamente verso il basso</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Scorri automaticamente verso l&apos;output</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Nascondi Quake window dopo il movimento del mouse</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Sfondo Blur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Usa all&apos;avvio</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Dimensione font</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacità</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Scroll</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Base</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interfaccia</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Altro</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Spazio di lavoro</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandi personalizzati</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Gestione remota</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Dimensione di default</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Salta al comando successivo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Torna al comando precedente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zoom più</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Zoom meno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Chiudi le altre finestre</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Chiudi finestra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Dividi orizzontalmente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nuova scheda</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Prossima scheda</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Scheda precedente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Seleziona lo spazio di lavoro a sinistra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Seleziona lo spazio di lavoro inferiore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Seleziona lo spazio di lavoro a destra</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Seleziona lo spazio di lavoro superiore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Split verticale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Titolo scheda</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Vai alla scheda 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Vai alla scheda 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Vai alla scheda 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Vai alla scheda 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Vai alla scheda 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Vai alla scheda 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Vai alla scheda 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Vai alla scheda 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Vai alla scheda 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Disattiva il controllo di flusso con Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profilo Shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Il nome non dovrebbe eccedere i 32 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Seleziona il file di chiave privata</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Il Terminale di Deepin è un emulatore di terminale avanzato con spazi di lavoro, finestre multiple, gestione remota, quake mode ed altre funzionalità utili nell&apos;uso quotidiano.
 Localizzazione italiana a cura di Massimo A. Carofano</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Schede</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Sposta il focus con l&apos;icona &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Seleziona scheda</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Seleziona il file da caricare</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Seleziona un percorso dove salvare il file</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>impostane un altro</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Chiudere questo terminale?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>C&apos;è ancora un processo in esecuzione, chiudendo il terminale lo interromperai.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Ci sono ancora %1 processi in esecuzione, chiudendo il terminale li interromperai.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Chiudere questa finestra?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Ci sono ancora processi in esecuzione nella finestra, chiudendola li interromperai tutti.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Programmi in esecuzione nel terminale</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Sicuro di voler disinstallarlo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Sicuro di voler disinstallare questa applicazione?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Non sarà più possibile utilizzare il terminale.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Imposta il percorso di lavoro</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Imposta la modalità finestra allavvio</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Esegui un comando nel terminale</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Esegui script nel terminale</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Esegui in primo piano</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Fai in modo che il terminale rimanga aperto alla conclusione</translation>
     </message>
@@ -789,12 +806,12 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Aggiungi Server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Nessun server</translation>
     </message>
@@ -802,12 +819,12 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Gestione remota</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Assicurati che i comandi RZ e SZ siano stati installati nel server prima di caricare o scaricare file</translation>
     </message>
@@ -815,7 +832,7 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -823,137 +840,137 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opzioni avanzate</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Aggiungi Server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nome server:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Richiesta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Indirizzo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Username:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Password:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificato:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Gruppo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Percorso:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Encoding:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tasto cancella:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Elimina chiave:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Elimina server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Modifica Server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Inserisci il nome del Server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Inserisci l&apos;indirizzo IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Inserisci la Porta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Inserisci l&apos;username</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Il nome server esiste già, </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>inseriscine un altro.</translation>
     </message>
@@ -961,7 +978,7 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -970,38 +987,48 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Finestra normale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Dividi schermo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Massimo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Schermo intero</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>La scorciatoia %1 non è valida, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>La scorciatoia %1 è già in uso, </translation>
     </message>
@@ -1009,55 +1036,55 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Inserisci</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>username: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>username@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>host remoto: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>numero sessione: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>titolo impostato dal programma: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nome programma: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>percorso corrente (breve): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>percorso corrente (completo): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>host locale: %h</translation>
     </message>
@@ -1065,90 +1092,90 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Apri nel file manager</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Dividi orizzontalmente</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Split verticale</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nuova scheda</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Esci dalla modalità fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Encoding</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandi personalizzati</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Gestione remota</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Carica file</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Scarica file</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
@@ -1156,21 +1183,21 @@ Localizzazione italiana a cura di Massimo A. Carofano</translation>
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_ko.ts
+++ b/translations/deepin-terminal_ko.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>이름:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>명령:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>단축키</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>필수 항목</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>명령 추가</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>명령 편집</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>명령 삭제</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>저장</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>이름을 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>명령을 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>이름이 이미 존재합니다</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>다른 이름을 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>명령 추가</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>사용자 지정 명령</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>찾기</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>사용자 정의 테마</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>스타일</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>가볍게</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>어두움</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>배경 색깔</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>1차 명령 프롬프트</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>2차 명령 프롬프트</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>확인</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>서버 삭제</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>%1을(를) 삭제하시겠습니까?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>새 창</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>설정 </translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>파일을 다운로드할 경로 입력</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>사용자 정의 테마</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>작업공간 닫기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>다른 작업 공간 닫기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>&quot;%1&quot;를 찾을 수 없습니다. 대신 &quot;%2&quot;를 시작합니다. 쉘 프로필을 확인하십시오.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot;을 열 수 없습니다. 실행할 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot;을 찾을 수 없습니다. 실행할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>탭 제목 형식</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>원격 탭 제목 형식</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>제목 이름 변경</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>다른 탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>선택시 복사</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>커서 깜박임</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>커서 스타일</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>키 입력시 스크롤</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>출력시 스크롤</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>포커스를 잃은 후 진동 창 숨기기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>배경 흐림</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>시작시 사용</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>글꼴</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>글꼴 크기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>불투명도</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>고급</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>커서</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>창</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>기본</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>인터페이스</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>단축키</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>기타</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>터미널</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>작업 공간</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>사용자 지정 명령</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>단축키 표시</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>원격 관리</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>전체화면</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>기본 크기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>붙여넣기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>전체 선택</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>다음 명령으로 건너뛰기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>이전 명령으로 건너뛰기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>확대</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>축소</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>다른 창 닫기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>창 닫기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>수평 분할</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>새 탭</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>다음 탭</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>이전 탭</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>왼쪽 작업공간 선택</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>하위 작업공간 선택</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>오른쪽 작업공간 선택</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>상위 작업공간 선택</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>수직 분할</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>탭 제목</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>탭1로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>탭2로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>탭3으로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>탭4로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>탭5로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>탭6으로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>탭7로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>탭8로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>탭9로 가기</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+S, Ctrl+Q를 사용하여 흐름 제어 비활성화</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>이름은 32자 이하여야 합니다</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>개인 키 파일 선택</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>터미널은 작업 공간, 여러 창, 원격 관리, 지진 모드 및 기타 기능을 갖춘 고급 터미널 에뮬레이터입니다.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>탭</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>포커스를 &quot;+&quot; 아이콘으로 전환</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>탭 선택</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>업로드할 파일 선택</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>파일을 저장할 디렉터리 선택</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>다른 것을 설정하십시오.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>이 터미널을 닫으시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>이 터미널에서 여전히 실행중인 프로세스가 있습니다. 터미널을 닫으면 터미널이 종료됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>이 터미널에서 여전히 %1 개의 프로세스가 실행 중입니다. 터미널을 닫으면 모든 터미널이 종료됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>이 창을 닫으시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>이 창에서 여전히 실행중인 프로세스가 있습니다. 창을 닫으면 모든 창이 종료됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>터미널에서 프로그램이 여전히 실행 중입니다</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>제거하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>이 응용프로그램을 제거하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>더 이상 터미널을 사용할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>작업 디렉토리 지정하기</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>시작 시 윈도우 모드 지정하기</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>터미널에서 명령 실행</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>터미널에서 스크립트 문자열 실행</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>진동 모드에서 실행</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>명령이 완료될 때 터미널 열기 유지하기</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>서버 추가</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>원격 관리</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>파일을 업로드 및 다운로드하려면 마우스 오른쪽 단추를 클릭하기 전에 rz 및 sz 명령이 서버에 설치되어 있는지 확인하십시오.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>찾기</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>고급 옵션</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>서버 추가</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>서버 이름:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>필수 항목</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>주소:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>포트:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>사용자 이름:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>비밀번호:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>인증서:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>그룹:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>경로:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>명령:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>인코딩:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>백스페이스 키:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>키 삭제:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>서버 삭제</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>서버 편집</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>저장</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>서버 이름을 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>IP 주소를 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>포트를 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>사용자 이름을 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>서버 이름이 이미 존재합니다.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>다른 서버 이름을 입력하십시오.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>보통 창</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>분할 화면</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>최대</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>전체화면</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1 단축키가 잘못됨,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>%1 단축키가 이미 사용 중이었습니다.</translation>
     </message>
@@ -1008,146 +1035,146 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>삽입</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>세션 번호: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>프로그램 이름:% n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>현재 디렉토리(short): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>현재 디렉토리(long): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>붙여넣기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>파일 관리도구에서 열기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>수평 분할</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>수직 분할</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>새 탭</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>전체화면 종료</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>전체화면</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>인코딩</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>사용자 지정 명령</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>원격 관리</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>파일 업로드</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>다운로드 파일</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>설정 </translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>

--- a/translations/deepin-terminal_ms.ts
+++ b/translations/deepin-terminal_ms.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Perintah:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Pintasan:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Diperlukan</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Tambah Perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Sunting Perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Padam Perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Sila masukkan satu nama</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Sila masukkan satu perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Nama sudah wujud,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>sila masukkan yang lain.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Tambah Perintah</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Belum ada perintah</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Perintah suai</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema Suai</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Gaya:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Ringan</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Gelap</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Warna hadapan:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Warna belakang:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prom PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prom PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sahkan</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Padam Pelayan</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Anda pasti mahu memadam %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Tetingkap baharu</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Taip laluan untuk muat turun fail</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema Suai</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sahkan</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Tutup ruang kerja</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Tutup ruang kerja lain</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Tidak dapat mencari &quot;%1&quot;, memulakan &quot;%2&quot; sebagai ganti. Sila periksa profil shell anda.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Tidak dapat membuka &quot;%1&quot;, gagal dijalankan</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Tidak dapat mencari &quot;%1&quot;, gagal dijalankan</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Output telah ditangguh dengan menekan Ctrl+S. Tekan Ctrl+Q untuk menyambung semula.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format tajuk tab</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format tajuk tab jauh</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Nama semula tajuk</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Tutup tab</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Tutup tab lain</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Salin ketika memilih</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Kerlipan kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Gaya kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Tatal ketika ketukan kekunci</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Tatal ketika output</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Sembunyi tetingkap Quake setelah hilang fokus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Latar belakang kabur</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Guna ketika permulaan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Saiz fon</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Kelegapan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Tatal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Tetingkap</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Asas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Antaramuka</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Pintasan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Lain-lain</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Ruang Kerja</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Perintah suai</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Pengurusan jauh</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Saiz lalai</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Tampal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Lompat ke perintah berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Lompat ke perintah terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zum masuk</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Zum keluar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Tutup tetingkap lain</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Tutup tetingkap</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Pisah mengufuk</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Tab baharu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Tab berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Tab terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Pilih ruang kerja kiri</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Pilih ruang kerja di bawah</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Pilih ruang kerja kanan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Pilih ruang kerja di atas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Pisah menegak</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Tajuk tab</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Pergi ke tab 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Pergi ke tab 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Pergi ke tab 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Pergi ke tab 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Pergi ke tab 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Pergi ke tab 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Pergi ke tab 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Pergi ke tab 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Pergi ke tab 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Lumpuhkan kawalan aliran menggunakan Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil Shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Nama tidak lebih dari 32 aksara</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Pilih fail kunci persendirian</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Pilih</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal ialah sebuah emulator terminal lanjutan dengan ruang kerja, tetingkap berbilang, pengurusan jauh, mod Quake dan lain-lain fitur.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Tukar fokus ke ikon &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Pilih tab</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Pilih fail untuk dimuat naik</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Muat naik</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Pilih satu direktori untuk menyimpan fail</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>sila tetapkan yang lain.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Tutup terminal ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Masih terdapat satu proses berjalan dalam terminal ini. Penutupan terminal akan mematikannya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Masih terdapat %1 proses berjalan dalam terminal ini. Penutupan terminal akan mematikan semuanya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Tutup tetingkap ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Masih terdapat proses berjalan dalam terminal ini. Penutupan terminal akan mematikan semuanya.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Program masih lagu berjalan di dalam terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Anda pasti mahu menyahpasangkannya?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Anda pasti mahu menyahpasang aplikasi ini?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Anda tidak dapat menggunakan Terminal lagi.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Tetapkan direktori kerja</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Tetapkan mod tetingkap ketika permulaan</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Lakukan satu perintah di dalam terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Jalankan rentetan skrip di dalam terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Jalankan dalam mod quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Biarkan terminal terbuka walaupun perintah selesai</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Tambah Pelayan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Belum ada pelayan</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Pengurusan jauh</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Pastikan perintah rz dan sz telah dipasang dalam pelayan sebelum mengklik kanan untuk muat naik dan muat turun fail.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Pilihan lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Tambah Pelayan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nama pelayan:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Diperlukan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Alamat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nama Pengguna:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Kata Laluan:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Sijil:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Kumpulan:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Laluan:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Perintah:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Pengekodan:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Kekunci Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Kekunci delete:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Padam pelayan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Sunting Pelayan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Sila masukkan nama pelayan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Sila masukkan alamat IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Sila masukkan port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Sila masukkan nama pengguna</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Nama pelayan sudah wujud,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>sila masukkan yang lain.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Tetingkap biasa</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Pisah skrin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Pintasan %1 tidak sah,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Pintasan %1 sudah digunakan,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Sisip</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nama pengguna: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nama pengguna@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>hos jauh: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>nombor sesi: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>Set tajuk oleh shell: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nama program: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>direktori semasa (singkatan): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>direktori semasa (panjang): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>hos setempat: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Tampal</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Buka dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Pisah mengufuk</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Pisah menegak</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Tab baharu</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Keluar dari skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Pengekodan</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Perintah suai</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Pengurusan jauh</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Muat naik fail</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Muat turun fail</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_nl.ts
+++ b/translations/deepin-terminal_nl.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Opdracht:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Sneltoetsen:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Vereist</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Opdracht toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Opdracht bewerken</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Opdracht verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Voer een naam in</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Voer een opdracht in</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Deze naam is al in gebruik;</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>kies een andere naam.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Opdracht toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Er zijn nog geen opdrachten</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Aangepaste opdrachten</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Eigen thema</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stijl:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Licht</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Donker</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Voorgrondkleur:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Achtergrondkleur:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Vraag PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Vraag PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Server verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Weet je zeker dat je %1 wilt verwijderen?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nieuw venster</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Geef de locatie op van het te downloaden bestand</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Eigen thema</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Werkblad sluiten</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Andere werkbladen sluiten</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>“%1” is niet aangetroffen, dus wordt “%2” gestart. Controleer je shellprofiel.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>“%1” kan niet worden geopend en worden gestart</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>“%1” is niet aangetroffen en kan daarom niet worden gestart</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Door het drukken op Ctrl+S is de uitvoer onderbroken. Druk op Ctrl+Q om te hervatten.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Tabbladnaamopmaak</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Tabbladnaamopmaak (beheer op afstand)</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Titelnaam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Tabblad sluiten</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Andere tabbladen sluiten</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Selecties kopiëren naar klembord</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Knipperende cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Cursorstijl</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Scrollen na toetsaanslag</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Scrollen na nieuwe uitvoer</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Quake-venster verbergen na verliezen van focus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Achtergrond vervagen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Opstartmodus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Lettertype</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Tekstgrootte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Doorzichtigheid</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Venster</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Uiterlijk</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Overig</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Werkblad</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Aangepaste opdrachten</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Beheer op afstand</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Standaardgrootte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Ga naar volgende opdracht</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Ga naar vorige opdracht</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Andere vensters sluiten</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Venster sluiten</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Horizontaal splitsen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Volgend tabblad</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Vorig tabblad</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Ga naar linkerwerkruimte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Ga naar onderste werkruimte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Ga naar rechterwerkruimte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Ga naar bovenste werkruimte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Verticaal splitsen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Tabbladnamen</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ga naar tabblad 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ga naar tabblad 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ga naar tabblad 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ga naar tabblad 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ga naar tabblad 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ga naar tabblad 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ga naar tabblad 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ga naar tabblad 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ga naar tabblad 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Uitvoer onderbreken/hervatten middels Ctrl+S en Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shellprofiel</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>De naam mag niet langer zijn dan 32 tekens</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Kies het privésleutelbestand</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Kiezen</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal is een geavanceerde terminalemulator met functies als werkbladen, meerdere vensters, beheer op afstand, quake-modus en nog veel meer.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Tabbladen</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Focussen op ‘+’-pictogram</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Ga naar tabblad</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Kies het te uploaden bestand</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Kies de map waarin het bestand moet worden opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>kies een andere.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Wil je dit terminalvenster sluiten?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Er is nog één proces actief in dit venster. Als je het venster sluit, wordt het proces afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Er zijn nog %1 processen actief in dit venster. Als je het venster sluit, worden ze afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Wil je dit venster sluiten?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Er zijn nog processen actief in dit venster. Als je het venster sluit, worden ze afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Er draaien nog programma&apos;s in de terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Weet je zeker dat je het wilt deïnstalleren?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Weet je zeker dat je dit programma wilt deïnstalleren?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Je kunt Deepin Terminal dan niet meer gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Stel de werkmap in</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Stel de standaard venstermodus in</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Voer een opdracht uit in het terminalvenster</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Script uitvoeren in terminalvenster</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Opstarten in quake-modus</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Terminal niet sluiten na afronden van opdracht</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Server toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Beheer op afstand</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Zorg er voor dat de rz- en sz-opdrachten geïnstalleerd zijn op de server zodat je bestanden kunt up- en downloaden middels de rechtermuisknop.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Geavanceerde opties</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Server toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Servernaam:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Vereist</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Poort:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Gebruikersnaam:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Wachtwoord:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificaat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Groep:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Opdracht:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Versleuteling:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Backspace-toets:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Toets verwijderen:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Server verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Server bewerken</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Voer een servernaam in</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Voer een ip-adres in</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Voer een poortnummer in</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Voer een gebruikersnaam in</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Deze naam is al in gebruik;</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>kies een andere naam.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normaal venster</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Gesplitst scherm</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximaal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>De sneltoets &apos;%1&apos; is ongeldig;</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>De sneltoets &apos;%1&apos; is al in gebruik;</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Invoegen</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>gebruikersnaam: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>gebruikersnaam@: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>host op afstand: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>sessienummer: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>naam ingesteld door shell: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>programmanaam: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>huidige map (verkort): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>huidige map (volledig): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>lokale host: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Openen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Horizontaal splitsen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Verticaal splitsen</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Versleuteling</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Aangepaste opdrachten</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Beheer op afstand</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Bestand uploaden</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Bestand downloaden</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>

--- a/translations/deepin-terminal_pl.ts
+++ b/translations/deepin-terminal_pl.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nazwa:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Komenda:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Skróty:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Wymagane</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Dodaj komendę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Edytuj komendę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Usuń komendę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Wpisz nazwę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Wpisz komendę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Taka nazwa już istnieje,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>wprowadź inną.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Dodaj Komendę</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Brak komend</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Komendy niestandardowe</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Własny motyw</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Styl:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Jasny</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Ciemny</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Kolor czcionki:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Kolor tła:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Usuń serwer</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Czy na pewno chcesz usunąć %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nowe okno</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Wpisz ścieżkę, aby pobrać plik</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Własny motyw</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Zamknij obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Zamknij pozostałe obszary robocze</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Nie udało się znaleźć „%1”, włączanie „%2”. Sprawdź swój profil powłoki.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Nie udało się otworzyć &quot;%1&quot;, nie można uruchomić</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Nie udało się znaleźć „%1”, nie można uruchomić</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Wyjście danych zostało zawieszone przez naciśnięcie Ctrl+S. Naciśnij Ctrl+Q, aby wznowić. </translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format tytułu karty</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format tytułu zdalnej karty</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Zmień nazwę tytułu</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Zamknij kartę</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Zamknij pozostałe karty</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopiuj przy zaznaczeniu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Miganie kursora</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Styl kursora</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Przewijaj po naciśnięciu klawisza</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Przewijaj przy wyjściu danych</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Ukryj okno Quake po utracie zaznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Rozmycie tła</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Przy uruchomieniu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Czcionka</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Nieprzezroczystość</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Zaawansowane</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Przewijanie</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Podstawowe</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interfejs</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Skróty</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Inne</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Komendy niestandardowe</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Zarządzanie zdalne</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Domyślny rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Przejdź do następnej komendy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Przejdź do poprzedniej komendy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Powiększ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Pomniejsz</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Zamknij pozostałe okna</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Zamknij okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Podział poziomy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Następna karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Poprzednia karta</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Zaznacz lewy obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Zaznacz dolny obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Zaznacz prawy obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Zaznacz górny obszar roboczy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Podział pionowy</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Nazwy kart</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Idź do karty 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Idź do karty 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Idź do karty 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Idź do karty 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Idź do karty 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Idź do karty 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Idź do karty 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Idź do karty 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Idź do karty 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Wyłącz kontrolę wyjścia danych skrótami Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil powłoki</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Nazwa nie powinna mieć więcej niż 32 znaki</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Wybierz plik klucza prywatnego</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Wybierz</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal to zaawansowany emulator terminala z obszarem roboczym, wieloma oknami, zarządzaniem zdalnym, trybem quake i innymi funkcjami.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Karty</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Przełącz zaznaczenie na ikonę „+” </translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Zaznacz kartę</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Wybierz plik do wysłania</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Wyślij</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Wybierz katalog, w którym chcesz zapisać plik</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>ustaw inną.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Zamknąć ten terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>W tym oknie nadal jest aktywny proces. Zamknięcie terminala go zabije.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>W tym terminalu nadal jest %1 aktywnych procesów. Zamknięcie zabije je wszystkie.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Zamknąć to okno?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>W tym oknie nadal są aktywne procesy. Zamknięcie zabije je wszystkie.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Niektóre programy są wciąż uruchomione w terminalu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Czy na pewno chcesz odinstalować?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Czy na pewno chcesz odinstalować tę aplikację?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Nie będziesz już mógł korzystać z terminala.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Ustaw katalog roboczy</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Ustaw tryb okna podczas uruchamiania</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Wykonaj komendę w terminalu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Uruchom ciąg skryptu w terminalu</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Uruchom w trybie quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Pozostaw terminal otwarty po zakończeniu komendy</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Dodaj serwer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Brak serwerów</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Zarządzanie zdalne</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Upewnij się, że komendy rz i sz zostały zainstalowane na serwerze, zanim klikniesz prawym przyciskiem, aby wysyłać i pobierać pliki.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opcje zaawansowane</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Dodaj serwer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nazwa serwera:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Wymagane</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nazwa użytkownika:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Hasło:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certyfikat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupa:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Ścieżka:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Komenda:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodowanie:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Przycisk Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Przycisk Delete:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Usuń serwer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Edytuj Serwer</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Wprowadź nazwę serwera</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Wprowadź adres IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Wprowadź port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Wprowadź nazwę użytkownika</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Nazwa serwera już istnieje,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>wprowadź inną.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normalne okno</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Podzielony ekran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Zmaksymalizowany</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Skrót %1 jest nieprawidłowy, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Skrót %1 był już w użyciu, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Wstaw</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nazwa użytkownika: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nazwa użytkownika@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>zdalny host: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>numer sesji: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>tytuł ustawiony przez powłokę: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nazwa programu: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>obecny katalog: %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>obecny katalog (pełna ścieżka): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>host: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Otwórz w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Podział poziomy</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Podział pionowy</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kodowanie</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Komendy niestandardowe</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Zarządzanie zdalne</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Wyślij plik</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Pobierz plik</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_pt.ts
+++ b/translations/deepin-terminal_pt.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Atalhos:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Necessário</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Adicionar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Editar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Comando eliminar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Introduza um nome</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Introduza um comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>O nome de já existe,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>introduza outro.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Adicionar comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Ainda sem comandos</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema personalizado</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Estilo:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Cor dianteira:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Cor traseira:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Eliminar servidor</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Tem a certeza que deseja eliminar %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Escreva o caminho para transferir o ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema personalizado</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Fechar área de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Fechar outras áreas de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Não foi possível localizar &quot;%1&quot;, a iniciar &quot;%2&quot; ao invés. Verifique o seu perfil da shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Não foi possível abrir o &quot;%1&quot;, incapaz de o executar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Não foi possível localizar &quot;%1&quot;, incapaz de o executar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>O resultado foi suspenso pressionando Ctrl+S. Pressionando Ctrl+Q para retomar.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Formato do título do separador</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Formato do título do separador remoto</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Renomear título</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Fechar separador</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Fechar outros separadores</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copiar ao selecionar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Piscar do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Estilo do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Deslocar ao tocar em tecla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Deslocar na saída</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Ocultar janela deslizante depois de perder o foco</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Fundo desfocado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Utilizar ao iniciar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacidade</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Rolar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Janela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Atalhos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Área de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Gestão remota</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Tamanho predefinido</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Ir para o próximo comando</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Ir para o comando anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Aumentar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Diminuir</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Fechar outras janelas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Fechar janela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Dividir horizontalmente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Novo separador</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Separador seguinte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Separador anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Selecionar a área de trabalho à esquerda</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Selecionar a área de trabalho inferior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Selecionar a área de trabalho à direita</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Selecionar a área de trabalho superior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Dividir verticalmente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Títulos de separador</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ir para separador 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ir para separador 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ir para separador 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ir para separador 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ir para separador 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ir para separador 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ir para separador 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ir para separador 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ir para separador 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Desativar o controlo de fluxo utilizando Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Perfil da shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>O nome não deve ter mais que 32 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Selecionar o ficheiro de chave privada</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Selecionar</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>O Terminal é um emulador de terminal avançado com áreas de trabalho, várias janelas, gestão remota, modo deslizante e outros recursos.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Separadores</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Mudar o foco para o ícone &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Selecionar separador</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Selecionar ficheiro para enviar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Selecionar um diretório para guardar o ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>defina outro.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Fechar este terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Ainda existe um processo em execução neste terminal. Fechar o terminal irá matá-lo.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Ainda existem %1 processos em execução neste terminal. Fechar o terminal irá matar todos eles.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Fechar esta janela?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Ainda existem processos em curso nesta janela. Fechar a janela irá matar todos eles.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Os programas ainda estão em execução no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Tem a certeza de que deseja desinstalá-lo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Tem a certeza de que deseja desinstalar esta aplicação?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Não poderá mais usar o Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Defina o diretório de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Definir o modo janela ao iniciar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Executar um comando no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Executar a sequência do script no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Executar em modo deslizante</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Mantenha o terminal aberto quando o comando terminar</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Adicionar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Ainda sem servidores</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Gestão remota</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Verifique se os comandos rz e sz foram instalados no servidor antes de clicar com o botão direito do rato para enviar e transferir ficheiros.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opções avançadas</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Adicionar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nome do servidor:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Necessário</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Endereço:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nome de utilizador:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Palavra-passe:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificado:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Caminho:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>A codificar:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tecla backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Tecla delete:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Eliminar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Editar servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Introduza um nome de servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Introduza um endereço de IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Introduza uma porta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Introduza um nome de utilizador</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>O nome de servidor já existe,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>introduza outro.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Janela normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Ecrã dividido</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximizada</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>O atalho %1 é inválido, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>O atalho %1 já estava em uso,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Inserir</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nome de utilizador: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nome de utilizador@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>anfitrião remoto: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>número da sessão: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>título definido pela shell: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nome do programa: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>diretório atual (curto): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>diretório atual (comprido): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>anfitrião local: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Abrir no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Dividir horizontalmente</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Dividir verticalmente</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Novo separador</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Sair de ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Gestão remota</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Enviar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Transferir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>

--- a/translations/deepin-terminal_pt_BR.ts
+++ b/translations/deepin-terminal_pt_BR.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Atalhos:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Obrigatório</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Adicionar Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Editar Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Comando Excluir</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Digite um nome</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Digite um comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>O nome já existe,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>insira outro.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Adicionar Comando</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Ainda sem comandos</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Tema Personalizado</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Estilo:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Cor de frente:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Cor de fundo:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Excluir Servidor</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Excluir %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Digite o caminho para baixar o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Tema Personalizado</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Fechar espaço de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Fechar outros espaços de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Impossível encontrar &quot;%1&quot;, iniciando com &quot;%2&quot; em vez disso. Verifique o perfil do shell.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Impossível abrir &quot;% 1&quot;, impossível executá-lo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Impossível localizar &quot;% 1&quot;, não foi possível executá-lo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>A saída foi suspensa ao pressionar Ctrl+S. Pressionando Ctrl+Q irá retomar.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Formato do título da aba</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Formato do título da aba remota</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Renomear título</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Fechar aba</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Fechar as outras abas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copiar ao selecionar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Intermitência do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Estilo do cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Rolar ao teclar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Rolar na saída</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Ocultar a janela Quake após perder o foco</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Desfocar o fundo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Utilizar na inicialização</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacidade</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Rolagem</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Janela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Atalhos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Área de Trabalho</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Gerenciamento remoto</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Tamanho padrão</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Ir para o próximo comando</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Ir para o comando anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Aumentar zoom</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Reduzir zoom</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Fechar outras janelas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Fechar janela</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Dividir horizontalmente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Nova aba</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Próxima aba</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Aba anterior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Selecionar o espaço de trabalho esquerdo</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Selecionar o espaço de trabalho inferior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Selecionar o espaço de trabalho direito</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Selecionar o espaço de trabalho superior</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Dividir verticalmente</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Títulos das abas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Ir para a aba 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Ir para a aba 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Ir para a aba 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Ir para a aba 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Ir para a aba 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Ir para a aba 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Ir para a aba 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Ir para a aba 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Ir para a aba 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Desative o controle de fluxo usando Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Perfil do shell</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>O nome não deve ter mais do que 32 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Selecionar o arquivo da chave privada</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Selecionar</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>O Terminal é um emulador de terminal avançado com espaço de trabalho, múltiplas janelas, gerenciamento remoto, modo quake e outros recursos.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Abas</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Alterar o foco para o ícone &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Selecionar aba</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Selecionar arquivo para enviar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Selecione um diretório para salvar o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>Defina outro.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Fechar este terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Há um processo em execução neste terminal. Ao fechar o terminal, irá matá-lo.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Existem %1 processos em execução neste terminal. Fechá-lo irá matar todos eles.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Fechar esta janela?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Existem processos em execução nesta janela. Ao fechá-la, irá matar todos eles.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Alguns programas estão sendo executados no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Desinstalá-lo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Desinstalar este aplicativo?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Você não poderá mais usar o Terminal.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Definir o diretório de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Definir o modo de janela ao iniciar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Executar um comando no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Executar o conjunto de scripts no terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Executar no modo quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Manter o terminal aberto quando o comando finalizar</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Adicionar Servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Ainda sem servidores</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Gerenciamento remoto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Antes de clicar com o botão direito para enviar e baixar os arquivos; verifique se os comandos rz e sz estão instalados no servidor.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opções avançadas</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Adicionar Servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Nome do servidor:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Obrigatório</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Endereço:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nome de Usuário:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Senha:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificado:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grupo:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Caminho:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Codificação:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tecla backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Excluir chave:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Excluir servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Editar Servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Digite o nome do servidor</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Digite um endereço de IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Digite uma porta</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Digite um nome de usuário</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>O nome do servidor já existe,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>insira outro.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Janela normal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Tela dividida</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximizado</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Tela Cheia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>O atalho %1 é inválido, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>O atalho %1 já está em uso, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Inserir</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>nome de usuário: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>nome de usuário@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>host remoto: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>número da sessão: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>título definido pelo shell: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>nome do programa: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>diretório atual (abreviado): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>diretório atual (longo): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>host local: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Abrir no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Dividir horizontalmente</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Dividir verticalmente</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Nova aba</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Sair da tela cheia</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Tela cheia</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandos personalizados</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Gerenciamento remoto</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Enviar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Baixar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>

--- a/translations/deepin-terminal_ro.ts
+++ b/translations/deepin-terminal_ro.ts
@@ -4,63 +4,63 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Nume:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Comandă:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Scurtături:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="209"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="215"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Necesar</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Adaugă comandă</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Modifică comanda</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Șterge comanda</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="197"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Adaugă</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="199"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Salvare</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="636"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -78,22 +78,22 @@
         <translation type="vanished">Salvare</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="388"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Vă rugăm să introduceți un nume</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="402"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Vă rugăm să introduceți o comandă</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="452"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Numele acesta există deja,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="453"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>vă rugăm să introduceți un alt nume.</translation>
     </message>
@@ -105,15 +105,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Adaugă comandă</translation>
+    </message>
+    <message>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
+        <source>No commands yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="76"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Comandă personalizată</translation>
     </message>
@@ -121,7 +126,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
@@ -129,53 +134,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="425"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="433"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -191,13 +196,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Ștergere server</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Sigur doriți să ștergeți% 1?</translation>
     </message>
@@ -205,24 +210,24 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Fereastră nouă</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Configurări</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Închidere</translation>
@@ -236,12 +241,12 @@
         <translation type="vanished">Închidere</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1808"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Introdu calea pentru a descărca fișierul</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2090"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -253,368 +258,383 @@
         <translation type="vanished">În regulă</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Copiază textul atunci când este selectat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Clipire cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Stilul cursorului</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Derulează conținutul la apăsarea tastelor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Derulează conținutul la ieșirea textului</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Închide vederea Quake atunci când fereastra nu mai este în centrul atenției</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="148"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Încețoșează fundalul</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Folosește la începere</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Dimensiunea fontului</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="171"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Opacitate</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Avansat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Cursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Fereastră</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Simplu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Interfață</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Scurtături</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1654"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Altele</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="37"/>
-        <location filename="../src/main/mainwindow.cpp" line="1652"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Spațiu de lucru</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Comandă personalizată</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Afișează scurtături</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Administrare de la distanță</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1701"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1702"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1703"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Redenumește titlul</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Redare ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Copiere</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>DImensiune implicită</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Lipire</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Selectează totul</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Sari la următoarea comandă</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Sari la comanda anterioară</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Mărește</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Micșorează</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Închide celelalte ferestre</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="493"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Închide celelalte spații de lucru</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1153"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1159"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1161"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1207"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Închide fereastra</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Închide spațiul de lucru</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Dedublare pe orizontală</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Dedublare pe verticală</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1683"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Găsire</translation>
     </message>
@@ -627,52 +647,52 @@
         <translation type="vanished">Șterge</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="392"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="639"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>vă rugăm să introduceți altul.</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="40"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminal este un emulator avansat pentru linia de comandă cu spațiu de lucru, ferestre multiple, control de la distanță, mod „quake” și alte caracteristici.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1650"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1670"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1699"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1755"/>
-        <location filename="../src/common/utils.cpp" line="146"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Alege fișierul de încărcat</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1762"/>
-        <location filename="../src/common/utils.cpp" line="151"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Încă mai rulează programe în terminal</translation>
     </message>
@@ -685,55 +705,55 @@
         <translation type="vanished">Ieşire</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Închideți terminalul?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="172"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Încă mai rulează un program în acest terminal. Dacă închideți terminalul, acesta va fi oprit.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Încă mai rulează %1 programe în acest terminal. Dacă închideți terminalul, toate acestea vor fi oprite.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Închideți această fereastră?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Încă mai rulează programe în acest terminal. Dacă închideți terminalul, toate acestea vor fi oprite.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1824"/>
-        <location filename="../src/common/utils.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Alegeți un directór pentru salvarea fișierului.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Sunteți sigur că doriți să îl dezinstalați?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Sunteți sigur că doriți să dezinstalați această aplicație?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Nu veți putea să mai utilizați terminalul de acum încolo.</translation>
     </message>
@@ -746,57 +766,57 @@
         <translation type="vanished">Înlocuire</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="330"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Execută o comandă în terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="333"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Rulează un string script în terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="324"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Stabilește directórul de lucru</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="327"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Stabilește modul ferestrei la pornire</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Rulează în modul Quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Păstrează terminalul deschis atunci când comanda termină de rulat</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="395"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Numele nu trebuie să aibă mai mult de 32 de caractere</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="578"/>
-        <location filename="../src/main/mainwindow.cpp" line="1830"/>
-        <location filename="../src/common/utils.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="574"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Alege fișierul cu cheia privată</translation>
     </message>
@@ -805,41 +825,41 @@
         <translation type="vanished">Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="127"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="129"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -848,20 +868,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="179"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Adaugă server</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
+        <source>No servers yet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Administrare de la distanță</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Asigurați-vă că comenzile rz și sz au fost instalate pe server înainte de a face clic-dreapta pentru a încărca și descărca fișiere</translation>
     </message>
@@ -869,7 +894,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="223"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
@@ -877,95 +902,95 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="67"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Opțiuni avansate</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="107"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Adaugă server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Numele serverului:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="147"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Necesar</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresă:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="162"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="183"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Nume de utilizator:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Parolă:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Certificat:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Cale fișier:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="234"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Comandă:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="240"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Încifrare:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tasta backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Tasta delete:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="274"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Șterge server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="295"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="296"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">Adaugă</translation>
@@ -979,39 +1004,37 @@
         <translation type="vanished">Adaugă</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="300"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Modifică server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="301"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation type="unfinished">Salvare</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="409"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="420"/>
         <source>tty</source>
-        <translation>tty</translation>
+        <translation type="vanished">tty</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Vă rugăm să introduceți un nume de server</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="515"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Vă rugăm să introduceți o adresă IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Vă rugăm să introduceți un port</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="526"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Vă rugăm să introduceți un nume de utilizator</translation>
     </message>
@@ -1020,36 +1043,28 @@
         <translation type="vanished">Salvare</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="405"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="417"/>
         <source>ascii-del</source>
-        <translation>ascii-del</translation>
+        <translation type="vanished">ascii-del</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="406"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="418"/>
         <source>auto</source>
-        <translation>auto</translation>
+        <translation type="vanished">auto</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="407"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="419"/>
         <source>control-h</source>
-        <translation>control-h</translation>
+        <translation type="vanished">control-h</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="408"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="416"/>
         <source>escape-sequence</source>
-        <translation>escape-sequence</translation>
+        <translation type="vanished">escape-sequence</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="540"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Numele serverului există deja,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="541"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>vă rugăm să introduceți un alt nume.</translation>
     </message>
@@ -1061,7 +1076,7 @@
         <translation type="vanished">Ok</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="388"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1070,38 +1085,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Dedublare ecran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Redare ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Fereastră normală</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="115"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maxim</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="285"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="294"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Scurtătura %1 este nevalidă,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="301"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="308"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="314"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Scurtătura %1 este deja în uz,</translation>
     </message>
@@ -1109,55 +1134,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="56"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="90"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="105"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="102"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="103"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="104"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1176,90 +1201,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="459"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Copiere</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="462"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Lipire</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="471"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Deschide</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="475"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Deschidere în managerul de fișiere</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="484"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Dedublare pe orizontală</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="487"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Dedublare pe verticală</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="497"/>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Ieșire redare ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="506"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Redare ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="509"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Găsire</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="513"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="523"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Compresie</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="525"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Comandă personalizată</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="527"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Administrare de la distanță</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Încarcă fișierul</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="532"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Descarcă fișierul</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
@@ -1279,21 +1304,21 @@
         <translation type="vanished">Ok</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished">Închidere</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>

--- a/translations/deepin-terminal_ru.ts
+++ b/translations/deepin-terminal_ru.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Сочетание клавиш:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Необходимо</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Добавить команду </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Редактировать команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Удалить команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Пожалуйста, введите название</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Пожалуйста, введите комманду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Имя уже существует,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>пожалуйста, введите другое.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Добавить команду </translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Пока нет команд</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Пользовательские команды</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Пользовательская тема</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Стиль:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Светлый</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Темный</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Передний цвет:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Задний цвет:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Подсказка PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Подсказка PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Применить</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Удалить сервер</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Вы уверены, что хотите удалить %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Новое окно</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Введите путь для загрузки файла</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Пользовательская тема</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Закрыть рабочую область</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Закрыть другие рабочие области</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Не удалось найти &quot;%1&quot;, вместо этого начинается &quot;%2&quot;. Пожалуйста, проверьте свой профиль оболочки.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>не смог открыть &quot;%1&quot;, невозможно запустить</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Не удалось найти &quot;%1&quot;, невозможно его запустить</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Вывод был приостановлен нажатием Ctrl+S. Нажмите Ctrl+Q, чтобы продолжить.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Формат заголовка вкладки</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Формат заголовка удаленной вкладки</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Переименовать заголовок</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Закрыть вкладку</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Закрыть другие вкладки</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Копировать при выборе</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Частота мигания курсора</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Стиль курсора</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Прокрутка нажатием клавиши</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Прокрутка при выводе</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Скрыть окно Выпадающего Терминала после потери фокуса</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Размытие фона</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Использовать при запуске</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Размер шрифта</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Непрозрачность</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Дополнительные</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Курсор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Интерфейс</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Сочетание клавиш</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Другое</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Терминал</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Рабочая область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Пользовательские команды</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Показать сочетания клавиш</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Удаленное управление</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Размер по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Перейти к следующий команде</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Перейти к предыдущей команде</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Отдалить</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Закрыть другие окна</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Закрыть окно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Разделить по горизонтали</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Следующая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Предыдущая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Выбрать левую рабочую область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Выбрать нижнюю рабочую область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Выбрать правую рабочую область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Выбрать верхнюю рабочую область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Разделить по вертикали</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Заголовки вкладок</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Перейти на вкладку 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Перейти на вкладку 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Перейти на вкладку 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Перейти на вкладку 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Перейти на вкладку 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Перейти на вкладку 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Перейти на вкладку 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Перейти на вкладку 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Перейти на вкладку 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Отключить управление потоком с помощью Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Профиль оболочки</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Имя должно быть не более 32 символов.</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Выберите файл закрытого ключа</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Deepin Терминал является передовым эмулятором терминала с рабочими областями, многооконным интерфейсом, удаленным управлением, выпадающим режимом и другими функциями. </translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Вкладки</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Переключить фокус на значок &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Выбрать вкладку</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Выберите файл для загрузки</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Загрузить</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Выберите каталог для сохранения файла</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>пожалуйста, установите другой.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Закрыть этот терминал?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>В этом терминале все еще выполняется процесс. Закрытие терминала убьет его.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>В этом терминале все еще выполняется %1 процесса/ов/. Закрытие терминала убьет их всех.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Закрыть это окно?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>В этом окне все еще выполняются процессы. Закрытие окна убьет их всех.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Программы все еще работают в терминале</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Вы действительно хотите его удалить?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Вы действительно хотите удалить это приложение?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Вы больше не сможете использовать Терминал.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Установить рабочий каталог</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Установить оконный режим при запуске</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Выполнить команду в терминале</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Запустить строку скрипта в терминале</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Запуск в выпадающем режиме</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Держать терминал открытым после завершения команды</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Добавить Сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Пока нет серверов</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Удаленное управление</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Убедитесь, что на сервере установлены команды rz и sz, прежде чем щелкнуть правой кнопкой мыши для загрузки и скачивания файлов.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Дополнительные опции</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Добавить Сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Имя сервера:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Необходимо</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Адрес:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Имя пользователя:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Пароль:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Сертификат:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Группа:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Кодировка:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Клавиша Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Удалить ключ:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Удалить сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Редактировать Сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Пожалуйста, введите имя сервера</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Пожалуйста, введите IP-адрес</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Пожалуйста, введите порт</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Пожалуйста введите имя пользователя</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Имя сервера уже существует,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>пожалуйста, введите другое.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Обычное окно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Разделенный экран</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Комбинация %1 недействительна,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Комбинация %1 уже используется,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>имя пользователя: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>имя пользователя@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>удаленный узел: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>номер сеанса: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>заголовок установлен оболочкой: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>название программы: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>текущий каталог (короткий): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>текущий каталог (длинный): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>локальный хост: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Открыть в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Разделить по горизонтали</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Разделить по вертикали</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Выйти из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Кодировка</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Пользовательские команды</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Удаленное управление</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Загрузить файл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Скачать файл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_sq.ts
+++ b/translations/deepin-terminal_sq.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Emër:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Urdhër:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Shkurtore:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>E domosdoshme</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Shtoni Urdhër</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Përpunoni Urdhër</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Fshije Urdhrin</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Shtoje</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Ju lutemi, jepni një emër</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Ju lutemi, jepni një urdhër</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Emri ekziston tashmë,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>ju lutemi, jepni një tjetër.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Shtoni Urdhër</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Ende pa urdhra</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Urdhra vetjakë</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Temë Vetjake</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stil:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>E çelët</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>E errët</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Ngjyrë përpara:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Ngjyrë pas:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Prompt PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Prompt PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Fshije Shërbyesin</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Jeni i sigurt se doni të fshihet %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Dritare e re</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Mbylle</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Shtypni shteg për shkarkim kartele</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Temë Vetjake</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Mbylle hapësirën e punës</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Mbyll hapësira të tjera pune</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>S’u gjet dot &quot;%1&quot;, në vend të tij po niset &quot;%2&quot;. Ju lutemi, kontrolloni profilin tuaj për shellin.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>S’u hap dot &quot;%1&quot;, s’arrihet të xhirohet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>S’u gjet dot &quot;%1&quot;, s’arrihet të xhirohet</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Shfaqja e përfundimit është pezulluar nga shtypja e tasteve Ctrl+S. Shtypni Ctrl+Q që të vazhdojë.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Format titulli skede</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Format titulli skede të largët</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Titull riemërtimi</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Mbylle skedën</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Mbylli skedat e tjera</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Kopjo kur përzgjidhet</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Xixëllim kursori</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Stil kursori</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Fshihe dritaren Quake pas humbjes së fokusit</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Turbulloje sfondin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Përdore gjatë nisjes</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Shkronja</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Madhësi shkronjash</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Patejdukshmëri</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Të mëtejshme</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Kursor</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Rrëshqitje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Dritare</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Elementare</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Ndërfaqe</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Të tjera</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Terminal</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Hapësirë Pune</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Urdhra vetjakë</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Administrim së largëti</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Madhësi parazgjedhje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Përzgjidhi krejt</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Kalo te urdhri pasues</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Kalo te urdhri i mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Zmadhoje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Zvogëloje</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Mbylli dritaret e tjera</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Mbylle dritaren</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Ndarje horizontale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Skedë e re</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Skeda pasuese</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Skeda e mëparshme</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Përzgjidhni hapësirën e punës majtas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Përzgjidhni hapësirën e poshtme të punës</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Përzgjidhni hapësirën e punës djathtas</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Përzgjidhni hapësirën e sipërme të punës</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Ndarje vertikale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Tituj skedash</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Shko te skeda 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Kalo te skeda 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Kalo te skeda 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Kalo te skeda 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Kalo te skeda 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Kalo te skeda 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Kalo te skeda 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Kalo te skeda 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Kalo te skeda 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Çaktivizoni kontroll rrjedhe duke përdorur Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Profil shelli</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Emri s’duhet të jetë më tepër se 32 shenja</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Përzgjidhni kartelën e kyçit privat</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Përzgjidhe</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Terminali është një emulues i thelluar terminali, me hapësira pune, dritare të shumta, administrim së largëti, mënyrë Quake dhe veçori të tjera.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Skeda</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Kaloje fokusin te ikona &quot;+&quot;</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Përzgjidhni skedë</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Përzgjidhni kartelë për ngarkim</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Ngarkim</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Përzgjidhni një drejtori ku të ruhet kartela</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>ju lutemi, caktoni një tjetër.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Të mbyllet ky terminal?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Ka ende një proces që xhiron në këtë terminal. Mbyllja e terminalit do ta asgjësojë.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Ka ende %1 procese që xhirojnë në këtë terminal. Mbyllja e terminalit do t’i asgjësojë krejt ata.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Të mbyllet dritarja?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Ka ende procese që xhirojnë në këtë dritare. Mbyllja e dritares do t’i asgjësojë krejt ata.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Ka ende programe që xhirojnë në terminal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Jeni i sigurt se doni të çinstalohet?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Jeni i sigurt se doni të çinstalohet ky aplikacion?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>S’do të jeni më në gjendje të xhironi Terminal-in.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Caktoni drejtorinë e punës</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Caktoni mënyrë dritareje kur hapet</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Ekzekutoni një urdhër te terminali</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Xhironi te terminali varg programthi</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Xhiroje nën mënyrën dridhje</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Kur urdhri përfundon, mbaje hapur terminalin</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Shtoni Shërbyes</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Ende pa shërbyes</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Administrim së largëti</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Përpara se të djathtasklikoni për ngarkim dhe shkarkim kartelash, sigurohuni që urdhrat rz dhe sz janë të instaluar te shërbyesi.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Mundësi të mëtejshme</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Shtoni Shërbyes</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Emër shërbyesi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>E domosdoshme</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adresë:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Portë:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Emër përdoruesi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Fjalekalim:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Dëshmi:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Shteg:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Urdhër:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodim:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Tasti Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Fshije tastin:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Fshije shërbyesin</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Shtoje</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Përpunoni Shërbyes</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Ju lutemi, jepni një emër shërbyesi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Ju lutemi, jepni një adresë IP</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Ju lutemi, jepni një portë</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Ju lutemi, jepni një emër përdoruesi</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Emri i shërbyesit ekziston tashmë,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>ju lutemi, jepni një tjetër.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Dritare normale</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Ndaje ekranin</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Shkurtorja %1 është e pavlefshme,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Shkurtorja %1 është tashmë në përdorim,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Futni</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>emër përdoruesi: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>emër_përdoruesi@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>strehë e largët: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>numër sesionesh: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>titull i caktuar nga shelli: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>emër programi: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>drejtoria e tanishme (shkurt): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>drejtoria e tanishme (gjatë): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>strehë vendore: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Hap</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Hape në përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Ndarje horizontale</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Ndarje vertikale</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Skedë e re</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Dil nga mënyra sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kodim</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Urdhra vetjakë</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Administrim së largëti</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Ngarkoni kartelë</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Shkarkoje kartelën</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Mbylle</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>

--- a/translations/deepin-terminal_sr.ts
+++ b/translations/deepin-terminal_sr.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Име:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Пречице:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Неопходно</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Додај команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Уреди команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Обриши команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додај</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Сачувај</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Унесите име</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Унесите команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Име већ постоји</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>Унесите друго име.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Додај команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Прилагођене команде</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Прилагођена тема</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Стил:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Светла</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Тамна</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Боја предњег плана:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Боја позадине:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Прозорче PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Прозорче PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Обриши сервер</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Заиста желите да обришете %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Нови прозор</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Подeшавања</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Унеси путању за преузимање датотеке</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Прилагођена тема</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Затвори радни простор</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Затвори остале радне просторе</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Није пронађено &quot;%1&quot;, уместо тога покрећем &quot;%2&quot;. Проверите ваш профил љуске.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Не могу да отворим &quot;%1&quot;, покретање није могуће</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Није пронађено &quot;%1&quot;, покретање није могуће</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Испис је обустављен притиском на Ctrl+S. Притисни Ctrl+Q за наставак.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Формат наслова картице</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Формат наслова удаљене картице</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Промени наслов</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Затвори картице</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Затвори остале картице</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Копирај при избору</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Трептање показивача</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Изглед показивача:</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Клизај притиском на тастер</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Клизај по исписима</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Сакриј спуштајући терминал када није у фокусу</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Замућена позадина</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Користи при покретању</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Фонт</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Величина фонта</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Прозирност</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Напредно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Показивач</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Клизање</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Прозор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Основно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Сучеље</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Пречице</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Остало</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Терминал</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Радни простор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Прилагођене команде</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Даљинско управљање</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Подразумевана величина</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Убаци</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Изабери све</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Иди на следећу команду</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Иди на претходну команду</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Увеличај</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Умањи</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Затвори остале прозоре</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Затвори прозор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Хоризонтална подела</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Нова картица</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Следећа картица</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Претходна картица</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Изабери леви радни простор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Изабери доњи радни простор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Изабери десни радни простор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Изабери горњи радни простор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Вертикална подела</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Пронађи</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Наслов картице</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Иди на картицу 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Иди на картицу 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Иди на картицу 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Иди на картицу 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Иди на картицу 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Иди на картицу 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Иди на картицу 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Иди на картицу 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Иди на картицу 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Управљај протицањем користећи Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Профил љуске</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Име не треба бити дуже од 32 карактера</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Изабери датотеку са приватним кључем</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Изабери</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Терминал је напредни емулатор терминала са дељивим прозорима, радним просторима, даљинским управљањем, спуштајућим режимом и другим функцијама.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Картице</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Пребаци фокус на &quot;+&quot; иконицу</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Изабери картице</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Изабери датотеку за отпремање</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Отпреми</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Изабери директоријум за чување датотеке</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>молимо поставите другу</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Затворити овај терминал?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Процес још ради у овом терминалу. Затварање терминала ће га убити.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>У овом терминалу ради %1 процеса. Затварање терминала ће их убити.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Затворити овај прозор?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>У овом прозору још раде процеси. Затварање прозора ће их убити.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Програми још раде у терминалу</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Заиста желите да уклоните?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Заиста желите да уклоните овај програм?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Више нећете моћи да користите терминал.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Постави радни директоријум</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Подеси режим прозора при покретању</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Изврши команду у терминалу</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Покрени скрипту у терминалу</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Покрени спуштајући режим</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Остави терминал отворен када је команда извршена</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Додај сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Даљинско управљање</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Уверите се да су rz и sz команде инсталиране на серверу пре коришћења десног клика за преузимање и отпремање датотека.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Напредне опције</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Додај сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Име сервера:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Неопходно</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Адреса:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Прикључак:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Корисничко име:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Лозинка:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Сертификат:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Група:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Путања:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Кодирање:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Backspace тастер:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Delete тастер:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Обриши сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додај</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Уреди сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Сачувај</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Унесите име сервера</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Унесите ИП адресу</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Унесите прикључак</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Унесите корисничко име</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Име сервера већ постоји,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>Унесите друго име.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Нормалан прозор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Подели екран</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Цео екран</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Пречица %1 је неважећа, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Пречица %1 је била већ у употреби, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Уметни</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>корисничко име: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>корисничко име@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>удаљени домаћин: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>број сесије: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>нслов задат од стране љуске: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>име програма: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>тренутни директоријум (кратко): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>тренутни директоријум (дугачко): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>локални домаћин: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Убаци</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Покрени</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Отвори у управнику података</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Хоризонтална подела</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Вертикална подела</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Нова картица</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Напусти цео екран</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Пронађи</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Кодирање</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Прилагођене команде</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Даљинско управљање</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Отпреми датотеку</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Преузми датотеку</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Подeшавања</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>

--- a/translations/deepin-terminal_tr.ts
+++ b/translations/deepin-terminal_tr.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Ad:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Komut:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Kısayollar:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Gerekli</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Komut Ekle</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Komut Düzenle</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Komut Sil</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Lütfen bir ad gir</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Lütfen bir komut gir</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>İsim zaten var,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>lütfen başka bir tane gir.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Komut Ekle</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Henüz komut yok</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Özel komutlar</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Özel Tema</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Stil:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Açık</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Koyu</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Ön renk:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Zemin rengi:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Komut İstemi PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Komut İstemi PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Sunucuyu Sil</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>%1 ögesini silmek istediğinize emin misiniz?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Yeni pencere</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Dosyanın indirileceği yolu yazın</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Özel Tema</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Çalışma alanını kapat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Diğer çalışma alanlarını kapat</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Onun yerine &quot;%2&quot; başlayarak &quot;%1&quot; bulunamadı. Lütfen kabuk profilinizi kontrol edin.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; açılamadı, çalıştırılamıyor</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>&quot;%1&quot; bulunamadı, çalıştırılamıyor</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Çıkış, Ctrl+S tuşlarına basılarak askıya alındı. Devam etmek için Ctrl+Q tuşlarına basın.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Sekme başlık biçimi</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Sekme başlık biçimini kaldır</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Başlığı yeniden adlandır</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Sekmeyi kapat</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Diğer sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Seçileni kopyala</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>İmleç yanıp sönmesi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>İmleç şekli</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Tuşa basıldığında kaydır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Çıkışta kaydır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Odakta olmadığında Quake penceresi gizle</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Arkaplanı bulanıklaştır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Başlangıçta kullan</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Yazı tipi</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Yazı tipi boyutu</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Saydamlık</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Gelişmiş</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>İmleç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Kaydırma</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Pencere</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Temel</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Arayüz</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Kısayollar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Diğerleri</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Uçbirim</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Çalışma alanı</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Özel komutlar</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Uzaktan yönetim</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Varsayılan boyut</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Tümünü seç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Sonraki komuta atla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Önceki komuta atla</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Yakınlıştır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Uzaklaştır</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Diğer pencereleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Pencereyi kapat</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Yatay böl</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Yeni sekme</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Sonraki sekme</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Önceki sekme</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Sol çalışma alanını seç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Alt çalışma alanını seç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Sağ çalışma alanını seç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Üst çalışma alanını seç</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Dikey böl</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Sekme başlıkları</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>1. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>2. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>3. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>4. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>5. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>6. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>7. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>8. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>9. sekmeye git</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+S, Ctrl+Q kullanarak akış kontrolünü devre dışı bırakın</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Kabuk profili</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>İsim 32 karakterden fazla olmamalıdır</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Özel anahtar dosyasını seç</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Seç</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Uçbirim, çalışma alanı, çoklu pencere, uzaktan yönetim, hızlı kip ve diğer özelliklere sahip gelişmiş uçbirim emülatörüdür.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Sekmeler</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Odağı &quot;+&quot; simgesine getirin</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Sekme seç</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Yüklenecek dosyayı seç</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Yükle</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Dosyayı kaydetmek için bir dizin seç</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>lütfen başka bir tane ayarla.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Bu uçbirim kapatılsın mı?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>Bu uçbirimde hala çalışan bir işlem var. Uçbirimin kapatılması işlemi öldürür.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>Bu uçbirimde hala %1 işlem çalışıyor. Uçbirimin kapatılması tüm işlemleri öldürür.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Bu pencereyi kapat?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>Bu pencerede hala çalışan işlemler var. Pencereyi kapatmak tümünü öldürecektir.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Uçbirimde hala çalışan programlar var</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Kaldırmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Bu uygulamayı kaldırmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Artık Uçbirimi kullanamayacaksınız.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Çalışma dizinini ayarla</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Başlangıçta pencere kipini ayarla</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Uçbirimde bir komut yürüt</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Uçbirimde kod dizesini çalıştır</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Quake kipinde çalıştır</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Komut bittiğinde uçbirimi açık tut</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Sunucu Ekle</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Henüz sunucu yok</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Uzaktan yönetim</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Dosyaları yüklemek ve indirmek için sağ tıklamadan önce sunucuda rz ve sz komutlarının yüklendiğinden emin olun.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Gelişmiş seçenekler</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Sunucu Ekle</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Sunucu adı:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Gerekli</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Port: </translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Kullanıcı adı:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Parola:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Sertifika:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Grup:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Yol:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Komut:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Kodlama:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Geriye silme tuşu:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Anahtarı sil:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Sunucuyu sil</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Sunucuyu Düzenle</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Lütfen bir sunucu adı gir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Lütfen bir IP adresi gir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Lütfen bir port gir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Lütfen bir kullanıcı adı gir</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Sunucu adı zaten var,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>lütfen başka bir tane gir.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Normal pencere</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Bölünmüş ekran</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Azami</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1 kısayolu geçersiz,</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>%1 kısayolu zaten kullanımdaydı,</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>kullanıcı adı: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>kullanıcıadı@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>uzak makineyi kaldır: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>oturum numarası: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>kabuğun belirlediği başlık: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>program adı: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>mevcut dizin (kısa): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>mevcut dizin (uzun): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>yerel makine: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Dosya yöneticisinde aç</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Yatay böl</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Dikey böl</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Yeni sekme</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çık</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Kodlama</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Özel komutlar</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Uzaktan yönetim</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Dosya yükle</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Dosya indir</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>

--- a/translations/deepin-terminal_ug.ts
+++ b/translations/deepin-terminal_ug.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>نامى:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>بۇيرۇق:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>تېزلەتمە كۇنۇپكىلار:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>زۆرۈر</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>بۇيرۇق قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>بۇيرۇقنى تەھرىرلەش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>بۇيرۇقنى ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>نامىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>بۇيرۇقنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>بۇ نام مەۋجۇت</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>قايتا كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈش</translation>
@@ -87,20 +89,20 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>بۇيرۇق قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>بۇيرۇق بەلگىلەش</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>ئۇسلۇب بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>ئۇسلۇب خاسلىقى:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>سۇس رەڭ</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>قېنىق رەڭ</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>ئالدى تەگلىك رەڭگى:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>كەينى تەگلىك رەڭگى:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>ئەسكەرتىش بەلگىسىPS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>ئەسكەرتىش بەلگىسىPS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزملەشتۈرۈش</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>مۇلازىمىتېرنى ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>%1 نى ئۆچۈرمەكچىمۇ؟</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>يېڭىدىن كۆزنەك قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>ھۆججەت ئورنىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>ئۇسلۇب بەلگىلەش</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزملەشتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>خىزمەت رايونىنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>باشقا خىزمەت رايونىنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>«%1”تېپىلمىغاچقا «%2» ئۇنىڭ ئورنىغا قوزغىتىلدى، Shell سەپلىمىسىنى تەكشۈرۈڭ.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>«%1”» ئېچىلمىدى، نورمال ئىشلەتكى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>«%1”» تېپىلمىدى، نورمال ئىشلەتكى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Ctrl+S نى بېسىپ بولدىڭىز، چىقىرىش توختىتىلدى. Ctrl+Q نى بېسىپ داۋاملاشتۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>بەتكۈچ نامى فورماتى</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>يىراق مۇساپىلىك بەتكۈچ نامى فورماتى</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>تېمىغا قايتا نام قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>بەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>باشقا بەتكۈچلەرنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>تېكىست تاللانغاندا چاپلاش تاختىسىغا ئاپتوماتىك كۆچۈرۈلىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>نۇر بەلگىسى كۆزنى چاقنىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>نۇر بەلگىسى ئۇسلۇبى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>كۇنۇپكا بېسىلغاندا سىيرىلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>چىقارغاندا سىيرىلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>فوكۇسنى يوقاتقاندىن كېيىن Quake كۆزنىكىنى يوشۇرسۇن</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>ئارقا كۆرۈنۈش غۇۋا</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>قوزغالغاندا ئىشلىتىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>خەت نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>خەت شەكلى چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>سۈزۈكلۈكى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>ئالىي</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>نۇر بەلگە</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>سىيرىلىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>ئاساسىي ئۇچۇر</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>ئۇلىنىش ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>تىزلەتمە كۇنۇپكىلار</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>باشقىلار</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>تېرمىنال</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>خىزمەت رايونى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>بۇيرۇق بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمە كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>يىراقتىن باشقۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>سۈكۈتتىكى سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>ھەممىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>كېيىنكىسى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>ئالدىنقىسى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>چوڭايتىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>كىچىكلىتىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>باشقا كۆزنەكلەرنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>كۆزنەكنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>ئېكراننى توغرىسىغا بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>يېڭى بەتكۈچ قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>كېيىنكى بەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>ئالدىنقى بەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>سولدىكى خىزمەت رايونىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>ئاستىدىكى خىزمەت رايونىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>ئوڭدىكى خىزمەت رايونىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>ئۈستىدىكى خىزمەت رايونىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>تىك ھالەتتە ئېكراننى بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>بەتكۈچ نامى</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>بەتكۈچ 1 گە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>بەتكۈچ 2 گە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>بەتكۈچ 3 كە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>بەتكۈچ 4 كە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>بەتكۈچ 5 كە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>بەتكۈچ 6 گە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>بەتكۈچ 7 گە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>بەتكۈچ 8 گە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>بەتكۈچ 9 غا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Ctrl+S ۋە Ctrl+Q بىلەن كونتروللاشنى چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell سەپلەش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>ئىسىم 32 ھەرپتىن ئېشىپ كەتمەسلىكى كېرەك</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>شەخسىي ئاچقۇچ ھۆججىتىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>تېرمىنال بىر گەۋدىلەشتۈرۈلگەن خىزمەت رايونى، كۆپ كۆزنەك، يىراقتىن باشقۇرۇش ۋە quake ھالىتى قاتارلىق ئىقتىدارلىرى بار ئىلغار تېرمىنال تەقلىدلىگۈچىسى.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>بەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>فوكۇسنى «+» سىنبەلگىسىگە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>بەتكۈچنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>يوللىماقچى بولغان ھۆججەتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>يوللاش</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>چۈشۈرۈلگەن ھۆججەتنى ساقلاش ئۈچۈن مۇندەرىجىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>قايتا تەڭشەش</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>تېرمىنالنى تاقامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>تېرمىنالدا يەنىلا 1 پىروگرامما ئىجرا بولۇۋاتىدۇ، تېرمىنالنى تاقىسىڭىز بۇ پىروگراممىمۇ تاقىلىدۇ.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>تېرمىنالدا يەنىلا %1 پىروگرامما ئىجرا بولۇۋاتىدۇ، تېرمىنالنى تاقىسىڭىز بۇ پىروگراممىمۇ تاقىلىدۇ.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>بۇ كۆزنەكنى تاقامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>كۆزنەكتىكى بەزى تېرمىناللاردا يەنىلا پىروگرامما ئىجرا بولۇۋاتىدۇ. كۆزنەكنى تاقاش بارلىق پىروگراممىلارنى يوقىتىدۇ.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>تېرمىنالدا يەنىلا پروگراممىلار ئىجرا بولۇۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>راستلا ئۆچۈرەمسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>تېرمىنالنى راستلا ئۆچۈرەمسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>ئۆچۈرسىڭىز بۇ ئىقتىدارنى ئىشلىتەلمەيسىز.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>تېرمىنالنىڭ قوزغىلىش مۇندەرىجىسىنى تەڭشەڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>تېرمىنالنىڭ ئېچىلىش ھالىتىنى تەڭشەڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>تېرمىنالدا پىروگرامما ئىجرا قىلىڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>تېرمىنالدا قوليازما تىزىمىغا يول قويۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>تېرمىنال quake ھالىتىدە قوزغالسۇن </translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>تېرمىنالنى  بۇيرۇق ياكى قوليازما ئىجرا نەتىجىسىنى كۆرسىتىدىغان قىلىپ تەڭشەش</translation>
     </message>
@@ -788,25 +805,25 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>مۇلازىمىتېر قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>يىراقتىن باشقۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>ھۆججەتلەرنى يوللاش ۋە چۈشۈرۈش ئۈچۈن ئوڭ تەرەپنى چېكىش تىزىملىكىنى ئىشلىتىشتىن بۇرۇن، مۇلازىمېتىرنىڭ rz ۋە sz بۇيرۇقلىرىنى ئورناتقانلىقىنى جەزملەشتۈرۈڭ.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>ئالىي تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>مۇلازىمىتېر قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>مۇلازىمىتېر نامى:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>زۆرۈر</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>ئادررېس:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>ئېغىز:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>ئىشلەتكۈچى نامى:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>پارول:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>گۇۋاھنامە:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>گۇرۇپپا:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>غول مۇندەرىجە:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>بۇيرۇق:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>كودلاش:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>كاتەكچە بويىچە چېكىنىش كۇنۇپكىسى:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>ئۆچۈرۈش كۇنۇپكىسى:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>مۇلازىمىتېرنى ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>مۇلازىمىتېرنى تەھرىرلەش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>مۇلازىمىتېر نامىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>IP ئادرېسنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>ئېغىزنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>ئىشلەتكۈچى نامىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>بۇ ئىسىم مۇلازىمىتېر مەۋجۇت</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>قايتا كىرگۈزۈڭ</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈش</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>نورمال كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>ئېكران بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>چوڭايتىش</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>تولۇق ئېكران</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1 تېزلەتكە كۇنۇپكا ئىناۋەتسىز</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>%1 تېزلەتمە كۇنۇپكا ئىشلىتىلىپ بولغان</translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>كىرگۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>ئىشلەتكۈچى ئىسمى: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>ئىشلەتكۈچى ئىسمى@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>يىراق مۇساپىلىك باش ئاپپارات: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>سۆزلىشىش نومۇرى: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>shell بەلگىلىگەن كۆزنەك نامى: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>پىروگرامما نامى: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>نۆۋەتتىكى مۇندەرىجە(قىسقا): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>نۆۋەتتىكى مۇندەرىجە(ئۇزۇن): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>يەرلىك باش ئاپپارات: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>ئوچۇق</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>ھۆججەت باشقۇرغۇچتا ئاچسۇن</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>ئېكراننى توغرىسىغا بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>تىك ھالەتتە ئېكراننى بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>يېڭى بەتكۈچ قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>پۈتۈن ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>كودلاش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>بۇيرۇق بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>يىراقتىن باشقۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>ھۆججەت يوللاش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>ھۆججەت چۈشۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈش</translation>

--- a/translations/deepin-terminal_uk.ts
+++ b/translations/deepin-terminal_uk.ts
@@ -1,84 +1,86 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>Ім&apos;я:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>Ярлики:</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>Вимагається</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>Додати команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>Редагувати команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>Вилучити команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додати</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>Будь ласка, введіть назву</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>Будь ласка, введіть команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>Таку назву вже визначено,</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>будь ласка, введіть іншу.</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -87,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>Додати команду</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>Команд ще немає</translation>
     </message>
@@ -100,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>Користувацькі команди</translation>
     </message>
@@ -108,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
@@ -116,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>Нетипова тема</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>Стиль:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>Світла</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>Темна</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>Колір тексту:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>Колір тла:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>Запит PS1:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>Запит PS2:</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
@@ -171,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>Вилучити сервер</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Ви впевнені, що хочете видалити %1?</translation>
     </message>
@@ -185,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>Нове вікно</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>Введіть шлях для завантаження файлу</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>Нетипова тема</translation>
     </message>
@@ -221,566 +223,581 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>Закрити робочий простір</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>Закрити інші робочі простори</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>Не вдалося знайти «%1». Запускаємося замість нього із «%2». Будь ласка, перевірте, чи правильно вказано ваш профіль оболонки.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>Не вдалося відкрити «%1». Не можемо його запустити.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>Не вдалося знайти «%1». Не можемо його запустити.</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>Виведення даних  було призупинено натисканням Ctrl+S.  Натисніть Ctrl+Q, щоб відновити його.</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>Формат заголовка вкладки</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>Формат заголовка віддаленої вкладки</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>Перейменувати назву</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>Закрити вкладку</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>Закрити інші вкладки</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>Копіювати при позначенні</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>Моргання курсору</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>Стиль курсора</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>Прокручування натисканням клавіші</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>Прокручування при введенні</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>Приховати вікно випадаючого Терміналу після втрати фокусу</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>Розмитий фон</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>Використовувати при запуску</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>Розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>Непрозорість</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>Додатково</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>Курсор</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>Прогорнути</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>Вікно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>Основний</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>Інтерфейс</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>Поєднання клавіш</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>Інше</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>Термінал</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>Робоча область</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>Користувацькі команди</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>Показати ярлики</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>Дистанційне керування</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>Стандартний розмір</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>Вибрати все</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>Перейти до наступної команди</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>Перейти до попередньої команди</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>Збільшити масштаб</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>Зменшити масштаб</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>Закрити інші вікна</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>Закрити вікно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>Горизонтальний розподіл</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>Нова вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>Наступна вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>Попередня вкладка</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>Вибрати лівий робочий простір</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>Вибрати нижній робочий простір</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>Вибрати правий робочий простір</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>Вибрати верхній робочий простір</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>Вертикальний розподіл</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>Заголовки вкладок</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>Перейти до вкладки 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>Перейти до вкладки 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>Перейти до вкладки 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>Перейти до вкладки 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>Перейти до вкладки 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>Перейти до вкладки 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>Перейти до вкладки 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>Перейти до вкладки 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>Перейти до вкладки 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>Вимкніть керування потоком даних за допомогою Ctrl+S, Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Профіль оболонки</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <source>History size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>Кількість символів у назві не повинна перевищувати 32</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>Вибрати файл приватного ключа</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>Обрати</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>Термінал - це розширений емулятор терміналу з робочим простором, декількома вікнами, віддаленим керуванням, режимом тремтіння і іншими функціями.</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>Вкладки</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>Перемкнути фоку на піктограму «+»</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>Вибрати вкладку</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>Вибрати файл для вивантаження</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>Виберіть каталог для зберігання файла</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>будь ласка, встановіть іншу.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>Закрити цей термінал?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>У цьому терміналі не завершено роботу одного з процесів. Закриття термінала призведе до примусового завершення роботи процесу.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>У цьому терміналі не завершено роботу %1 процесів. Закриття термінала призведе до примусового завершення роботи усіх цих процесів.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>Закрити це вікно?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>У цьому терміналі не завершено роботу процесів. Закриття термінала призведе до примусового завершення роботи усіх цих процесів.</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>Програми все ще працюють у терміналі</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>Ви справді хочете її вилучити?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>Ви справді хочете вилучити цю програму?</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>Після цього ви не зможете користуватися «Терміналом».</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>Встановити робочий каталог</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>Встановити режим вікна після запуску</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>Виконати команду у терміналі</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>Запустити рядок скрипту у терміналі</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>Запустити у режимі Quake</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>Не закривати термінал після завершення роботи команди</translation>
     </message>
@@ -788,12 +805,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>Додати сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>Серверів ще немає</translation>
     </message>
@@ -801,12 +818,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>Дистанційне керування</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>Переконайтеся, що на сервері встановлено програми rz і sz, перш ніж клацати правою кнопкою миші для вивантаження та отримання файлів.</translation>
     </message>
@@ -814,7 +831,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
@@ -822,137 +839,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>Розширені параметри</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>Додати сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>Ім&apos;я серверу:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>Вимагається</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>Адреса:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>Ім&apos;я користувача:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>Пароль:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>Сертифікат:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>Група:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>Шлях:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>Кодування:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>Клавіша Backspace:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>Видалити ключ:</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>Видалити сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додати</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>Редагувати сервер</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>Будь ласка, введіть назву сервера</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>Будь ласка, введіть IP-адресу</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>Будь ласка, введіть порт</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>Будь ласка, введіть ім&apos;я користувача</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>Сервер із такою назвою вже існує,</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>будь ласка, введіть іншу назву.</translation>
     </message>
@@ -960,7 +977,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -969,38 +986,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>Нормальне вікно</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>Розділити екран</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>Клавіатурне скорочення %1 є некоректним, </translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>Клавіатурне скорочення %1 вже вжито, </translation>
     </message>
@@ -1008,55 +1035,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>користувач: %u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>користувач@: %U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>віддалений вузол: %h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>номер сеансу: %#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>заголовок від командної оболонки: %w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>назва програми: %n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>поточний каталог (скорочено): %d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>поточний каталог (повністю): %D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>локальний вузол: %h</translation>
     </message>
@@ -1064,90 +1091,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>Відкрити у файловому менеджері</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>Горизонтальний розподіл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>Вертикальний розподіл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>Нова вкладка</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>Вийти з повноекранного режиму</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>Кодування</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>Користувацькі команди</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>Дистанційне керування</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>Вивантажити файл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>Завантажити файл</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
@@ -1155,21 +1182,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>

--- a/translations/deepin-terminal_zh_CN.ts
+++ b/translations/deepin-terminal_zh_CN.ts
@@ -226,7 +226,7 @@
         <location filename="../src/views/listview.cpp" line="289"/>
         <location filename="../src/views/listview.cpp" line="478"/>
         <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
-        <location filename="../src/common/utils.cpp" line="228"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
@@ -246,54 +246,54 @@
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="96"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>关闭工作区</translation>
     </message>
     <message>
         <location filename="../src/views/termwidget.cpp" line="507"/>
-        <location filename="../src/settings/settings_translation.cpp" line="92"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>关闭其他工作区</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1167"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 “%1”，已启动“%2”代替。请检查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不开“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1175"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1205"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已经按下Ctrl+S，输出被挂起。可以按下Ctrl+Q继续。</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="120"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="122"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>远程标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
         <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="68"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>重命名标题</translation>
@@ -311,343 +311,347 @@
         <translation>关闭其他标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="18"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>选中文字时自动复制到剪切板</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="20"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>光标闪烁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="22"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>光标风格</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="24"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>按键时滚动</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="26"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>输出时滚动</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="394"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation>允许Ctrl+滑动滚轮缩放文本大小</translation>
+        <translation type="vanished">允许Ctrl+滑动滚轮缩放文本大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="28"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>丢失焦点后隐藏雷神窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="30"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Quake window animation speed</source>
         <translation>雷神窗口动画速度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="32"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>背景模糊</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="34"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>启动时使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="36"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>字体</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="38"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>字体大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="40"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="42"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="44"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>光标</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="46"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="48"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="50"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>基础设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="52"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>界面</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="54"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="56"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="58"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
         <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>终端</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="60"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="62"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="64"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="66"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="70"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
         <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="72"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="74"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>默认大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="76"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="78"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="80"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="82"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>跳转到下一个命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="84"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>跳转到上一个命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="86"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="88"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>缩小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="90"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>关闭其他窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="94"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>关闭窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="98"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="100"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="102"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>下一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="104"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
         <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>上一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="106"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>选择左边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="108"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>选择下面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="110"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
         <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>选择右边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="112"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>选择上面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="114"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
         <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
         <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>标签标题</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="124"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>切换到标签 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="126"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>切换到标签 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="128"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
         <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>切换到标签 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="130"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>切换到标签 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="132"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>切换到标签 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="134"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
         <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>切换到标签 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="136"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>切换到标签 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="138"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>切换到标签 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="140"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
         <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>切换到标签 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="142"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="144"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="146"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>History size</source>
         <translation>历史回滚行数</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation>在双击选中区域包含特殊符号</translation>
     </message>
     <message>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
@@ -663,7 +667,7 @@
     <message>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
         <location filename="../src/main/mainwindow.cpp" line="1837"/>
-        <location filename="../src/common/utils.cpp" line="117"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
@@ -689,115 +693,115 @@
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1761"/>
-        <location filename="../src/common/utils.cpp" line="132"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>选择要上传的文件</translation>
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1768"/>
-        <location filename="../src/common/utils.cpp" line="137"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
         <location filename="../src/main/mainwindow.cpp" line="1831"/>
-        <location filename="../src/common/utils.cpp" line="111"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>选择下载文件的保存目录</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="397"/>
+        <location filename="../src/main/service.cpp" line="396"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>请重新设置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="157"/>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>关闭此终端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="158"/>
-        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>该终端中仍然有1个进程在运行，关闭终端将杀死进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="162"/>
-        <location filename="../src/common/utils.cpp" line="196"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>该终端中仍然有%1个进程在运行，关闭终端将杀死进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="167"/>
-        <location filename="../src/common/utils.cpp" line="187"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>关闭这个窗口？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="168"/>
-        <location filename="../src/common/utils.cpp" line="188"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>窗口内一些终端仍然有进程在运行，关闭窗口会杀死所有进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="205"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>终端仍然有程序在运行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="205"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>您确定要卸载它吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="218"/>
-        <location filename="../src/common/utils.cpp" line="222"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您确定要卸载终端吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="219"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸载后将无法再使用该应用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
-        <location filename="../src/common/utils.cpp" line="273"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="307"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>设置终端的启动目录</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="310"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>设置终端开启的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="313"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>在终端中运行⼀个程序</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="316"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>在终端中允许脚本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="319"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>设置终端以雷神模式启动</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="322"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>设置终端显示命令或脚本执行后的结果</translation>
     </message>
@@ -977,7 +981,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="393"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -986,32 +990,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>正常窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最大化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="129"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="712"/>
+        <location filename="../src/settings/settings.cpp" line="718"/>
         <source>Fast</source>
         <translation>快</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="717"/>
+        <location filename="../src/settings/settings.cpp" line="723"/>
         <source>Slow</source>
         <translation>慢</translation>
     </message>
@@ -1182,21 +1186,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="175"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>关 闭</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="208"/>
-        <location filename="../src/common/utils.cpp" line="240"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>

--- a/translations/deepin-terminal_zh_HK.ts
+++ b/translations/deepin-terminal_zh_HK.ts
@@ -4,83 +4,83 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>捷徑：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>必填</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>添加命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>編輯命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>刪除命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>保 存</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>請輸入名稱</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>請輸入命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>該名稱已存在，</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>請重新輸入</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -89,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>添加命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>未添加自定義命令</translation>
     </message>
@@ -102,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>自定義命令</translation>
     </message>
@@ -110,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -118,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>自定義主題</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>主題風格：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>淺色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>前景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>背景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>提示符PS1：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>提示符PS2：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -173,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>您確定要刪除 %1 嗎？</translation>
     </message>
@@ -187,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>新建視窗</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>關 閉</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>請輸入下載文件的路徑</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>自定義主題</translation>
     </message>
@@ -223,576 +223,585 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>刪 除</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>關閉工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>關閉其他工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 「%1」，已啟動「%2」代替。請檢查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不開“%1”，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到「%1」，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已經按下Ctrl+S，輸出被掛起。可以按下Ctrl+Q繼續。</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>標籤標題格式</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>遠程標籤標題格式</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>重命名標題</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>選中文字時自動複製到剪切板</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>光標閃爍</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>光標風格</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>按鍵時滾動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>輸出時滾動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="394"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation>允許Ctrl+滑動滾輪縮放文字大小</translation>
+        <translation type="vanished">允許Ctrl+滑動滾輪縮放文字大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>丟失焦點後隱藏雷神視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>背景模糊</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>啟動時使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>字體</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>字體大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>鼠標</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>滑鼠滾輪</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>終端</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>自定義命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>遠程管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>默認大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>選擇全部</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>跳轉到下一個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>跳轉到上一個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>拉近</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>拉遠</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>關閉其他視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>關閉視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>橫向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>新建標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>選擇左邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>選擇下面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>選擇右邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>選擇上面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>縱向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>標籤標題</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>切換到標籤 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>切換到標籤 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>切換到標籤 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>切換到標籤 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>切換到標籤 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>切換到標籤 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>切換到標籤 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>切換到標籤 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>切換到標籤 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="146"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>History size</source>
         <translation>歷史回滾行數</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation>在雙擊選中區域包含特殊符號</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>名稱長度不得超過32個字符</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>選擇私鑰文件</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>選擇</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>終端是⼀款集⼯作區、多視窗、遠程管理、雷神模式等功能的⾼級終端模擬器。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光標焦點切換至「+」圖標</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>選擇標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>選擇要上傳的文件</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>上傳</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>選擇下載文件的保存目錄</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>關閉此終端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>該終端中仍然有1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>該終端中仍然有%1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>關閉這個視窗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>視窗內一些終端仍然有進程在運行，關閉視窗會殺死所有進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>終端仍然有程序在運行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>你確定要解除安裝嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您確定要卸載終端嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸載後將無法再使用該應用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>設置終端的啟動目錄</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>設置終端開啟的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>在終端運行一個程序</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>在終端中允許腳本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>雷神模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>設置終端顯示命令或腳本執行後的結果</translation>
     </message>
@@ -800,12 +809,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>添加伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>未添加伺服器</translation>
     </message>
@@ -813,12 +822,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>遠程管理</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation> 在您使用右鍵菜單進行上傳和下載文件之前， 請先確保伺服器已經安裝了rz和sz命令。</translation>
     </message>
@@ -826,7 +835,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -834,137 +843,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>高級選項</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>添加伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>伺服器名：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>必填</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>地址：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>端口：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>用戶名稱：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>密碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>證書：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>分組：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>路徑：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>編碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>退格鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>刪除鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>編輯伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>保 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>請輸入伺服器名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>請輸入IP位址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>請輸入端口</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>請輸入用戶名</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>該伺服器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>請重新輸入</translation>
     </message>
@@ -972,7 +981,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -981,38 +990,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>正常視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最⼤化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1為無效快捷鍵，</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>快捷鍵%1已被佔用，</translation>
     </message>
@@ -1020,55 +1039,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>用戶名：%u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>用戶名@：%U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>遠程主機：%h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>會話編號：%#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>shell設定的窗口標題：%w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>程序名：%n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>當前目錄（短）：%d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>當前目錄（長）：%D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>本地主機：%h</translation>
     </message>
@@ -1076,90 +1095,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>在文件管理器中打開</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>橫向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>縱向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>新建標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>自定義命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>遠程管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>上傳文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>下載文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
@@ -1167,21 +1186,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>關 閉</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>

--- a/translations/deepin-terminal_zh_TW.ts
+++ b/translations/deepin-terminal_zh_TW.ts
@@ -4,83 +4,83 @@
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
         <translation>名稱：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="114"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="116"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
         <translation>快速鍵：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="127"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="128"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="205"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="211"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="190"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="196"/>
         <source>Required</source>
         <translation>必須</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="154"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="139"/>
         <source>Add Command</source>
         <translation>加入命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="160"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="145"/>
         <source>Edit Command</source>
         <translation>編輯命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="170"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="155"/>
         <source>Delete Command</source>
         <translation>刪除命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="191"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="193"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="195"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>儲 存</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="372"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="357"/>
         <source>Please enter a name</source>
         <translation>請輸入名稱</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="386"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="371"/>
         <source>Please enter a command</source>
         <translation>請輸入命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="436"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="421"/>
         <source>The name already exists,</source>
         <translation>該名稱已存在，</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="437"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="422"/>
         <source>please input another one.</source>
         <translation>請重新輸入</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="618"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="603"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -89,12 +89,12 @@
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="212"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="197"/>
         <source>Add Command</source>
         <translation>加入命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="216"/>
+        <location filename="../src/customcommand/customcommandpanel.cpp" line="201"/>
         <source>No commands yet</source>
         <translation>未添加自訂指令</translation>
     </message>
@@ -102,7 +102,7 @@
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="50"/>
+        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
         <translation>自訂命令</translation>
     </message>
@@ -110,7 +110,7 @@
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="146"/>
+        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="131"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -118,53 +118,53 @@
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="236"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="221"/>
         <source>Custom Theme</source>
         <translation>自訂主題</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="260"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="245"/>
         <source>Style:</source>
         <translation>主題風格：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="264"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="249"/>
         <source>Light</source>
         <translation>淺色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="269"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="254"/>
         <source>Dark</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="323"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="308"/>
         <source>Fore color:</source>
         <translation>前景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="330"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="315"/>
         <source>Back color:</source>
         <translation>背景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="348"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="333"/>
         <source>Prompt PS1:</source>
         <translation>提示符PS1：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="352"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="337"/>
         <source>Prompt PS2:</source>
         <translation>提示符PS2：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="423"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="408"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
+        <location filename="../src/views/customthemesettingdialog.cpp" line="416"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -173,13 +173,13 @@
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
         <source>Delete Server</source>
         <translation>刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="298"/>
-        <location filename="../src/views/listview.cpp" line="492"/>
+        <location filename="../src/views/listview.cpp" line="283"/>
+        <location filename="../src/views/listview.cpp" line="477"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>確定刪除 %1？</translation>
     </message>
@@ -187,35 +187,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="269"/>
-        <location filename="../src/main/mainwindow.cpp" line="324"/>
+        <location filename="../src/main/mainwindow.cpp" line="255"/>
+        <location filename="../src/main/mainwindow.cpp" line="310"/>
         <source>New window</source>
         <translation>新增視窗</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="339"/>
+        <location filename="../src/main/mainwindow.cpp" line="325"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="755"/>
+        <location filename="../src/main/mainwindow.cpp" line="741"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="757"/>
+        <location filename="../src/main/mainwindow.cpp" line="743"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>離 開</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1829"/>
+        <location filename="../src/main/mainwindow.cpp" line="1815"/>
         <source>Type path to download file</source>
         <translation>輸入位置以下載檔案</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2135"/>
+        <location filename="../src/main/mainwindow.cpp" line="2121"/>
         <source>Custom Theme</source>
         <translation>自訂主題</translation>
     </message>
@@ -223,576 +223,585 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="304"/>
-        <location filename="../src/views/listview.cpp" line="493"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="236"/>
-        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/views/listview.cpp" line="289"/>
+        <location filename="../src/views/listview.cpp" line="478"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="252"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="305"/>
+        <location filename="../src/views/listview.cpp" line="290"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>刪 除</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="494"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
+        <location filename="../src/views/listview.cpp" line="479"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="225"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="514"/>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="504"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close workspace</source>
         <translation>關閉工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="517"/>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/views/termwidget.cpp" line="507"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Close other workspaces</source>
         <translation>關閉其他工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1177"/>
+        <location filename="../src/views/termwidget.cpp" line="1172"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 「%1」，已啟動「%2」代替。請檢查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1183"/>
+        <location filename="../src/views/termwidget.cpp" line="1178"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不開“%1”，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1185"/>
+        <location filename="../src/views/termwidget.cpp" line="1180"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到「%1」，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1215"/>
+        <location filename="../src/views/termwidget.cpp" line="1210"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已經按下Ctrl+S，輸出被掛起。可以按下Ctrl+Q繼續。</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="132"/>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab title format</source>
         <translation>標籤標題格式</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="134"/>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Remote tab title format</source>
         <translation>遠端標籤標題格式</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamedlg.cpp" line="203"/>
-        <location filename="../src/views/tabbar.cpp" line="504"/>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
+        <location filename="../src/views/tabbar.cpp" line="489"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Rename title</source>
         <translation>重命名分頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="498"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="483"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="501"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/views/tabbar.cpp" line="486"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="17"/>
         <source>Copy on select</source>
         <translation>選取時複製</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="19"/>
         <source>Cursor blink</source>
         <translation>游標閃爍</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="21"/>
         <source>Cursor style</source>
         <translation>游標樣式</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="23"/>
         <source>Scroll on keystroke</source>
         <translation>點擊鍵盤時捲動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="25"/>
         <source>Scroll on output</source>
         <translation>輸出時捲動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="394"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation>允許Ctrl+滑動滾輪縮放文字大小</translation>
+        <translation type="vanished">允許Ctrl+滑動滾輪縮放文字大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Hide Quake window after losing focus</source>
         <translation>失去焦點時隱藏雷神視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
-        <location filename="../src/main/service.cpp" line="159"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <source>Quake window animation speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/main/service.cpp" line="147"/>
         <source>Blur background</source>
         <translation>模糊背景</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Use on starting</source>
         <translation>啟動時使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Font</source>
         <translation>字型</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font size</source>
         <translation>字型大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
-        <location filename="../src/main/service.cpp" line="182"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/main/service.cpp" line="170"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Cursor</source>
         <translation>游標</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Scroll</source>
         <translation>捲動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Interface</source>
         <translation>界面</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1671"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/terminalapplication.cpp" line="36"/>
-        <location filename="../src/main/mainwindow.cpp" line="1669"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/terminalapplication.cpp" line="25"/>
+        <location filename="../src/main/mainwindow.cpp" line="1655"/>
         <source>Terminal</source>
         <translation>終端機</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Workspace</source>
         <translation>工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Custom commands</source>
         <translation>自訂命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Display shortcuts</source>
         <translation>顯示快速鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Remote management</source>
         <translation>遠端管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
-        <location filename="../src/main/mainwindow.cpp" line="1735"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1721"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Default size</source>
         <translation>預設大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Jump to next command</source>
         <translation>跳到下個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to previous command</source>
         <translation>跳到上個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Zoom out</source>
         <translation>縮小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Close other windows</source>
         <translation>關閉其他視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
         <source>Close window</source>
         <translation>關閉視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Horizontal split</source>
         <translation>水平分割</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>New tab</source>
         <translation>建立標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
-        <location filename="../src/main/mainwindow.cpp" line="1715"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1701"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select left workspace</source>
         <translation>選擇左邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select lower workspace</source>
         <translation>選擇下面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1717"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1703"/>
         <source>Select right workspace</source>
         <translation>選擇右邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select upper workspace</source>
         <translation>選擇上面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Vertical split</source>
         <translation>垂直分割</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1700"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1686"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Tab titles</source>
         <translation>標籤標題</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 1</source>
         <translation>切換到標籤 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 2</source>
         <translation>切換到標籤 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
-        <location filename="../src/main/mainwindow.cpp" line="1718"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1704"/>
         <source>Go to tab 3</source>
         <translation>切換到標籤 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 4</source>
         <translation>切換到標籤 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 5</source>
         <translation>切換到標籤 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
-        <location filename="../src/main/mainwindow.cpp" line="1719"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Go to tab 6</source>
         <translation>切換到標籤 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="149"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 7</source>
         <translation>切換到標籤 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="151"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 8</source>
         <translation>切換到標籤 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="153"/>
-        <location filename="../src/main/mainwindow.cpp" line="1720"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Go to tab 9</source>
         <translation>切換到標籤 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="155"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="157"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="146"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>History size</source>
         <translation>歷史回滾行數</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="517"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="379"/>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <source>Include special character(s) in double click selections</source>
+        <translation>在雙擊選中區域包含特殊符號</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="502"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>名稱長度不得超過32個字元</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="583"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="568"/>
         <source>Select the private key file</source>
         <translation>選擇私鑰檔案</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="587"/>
-        <location filename="../src/main/mainwindow.cpp" line="1851"/>
-        <location filename="../src/common/utils.cpp" line="133"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="572"/>
+        <location filename="../src/main/mainwindow.cpp" line="1837"/>
+        <location filename="../src/common/utils.cpp" line="141"/>
         <source>Select</source>
         <translation>選擇</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="39"/>
+        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
         <translation>終端機是個進階的終端模擬器，具備視窗切割、工作區、遠端管理、雷神模式等其他功能。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1667"/>
+        <location filename="../src/main/mainwindow.cpp" line="1653"/>
         <source>Tabs</source>
         <translation>標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1687"/>
+        <location filename="../src/main/mainwindow.cpp" line="1673"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光標焦點切換至「+」圖標</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1716"/>
+        <location filename="../src/main/mainwindow.cpp" line="1702"/>
         <source>Select tab</source>
         <translation>選擇標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1775"/>
-        <location filename="../src/common/utils.cpp" line="148"/>
+        <location filename="../src/main/mainwindow.cpp" line="1761"/>
+        <location filename="../src/common/utils.cpp" line="156"/>
         <source>Select file to upload</source>
         <translation>選擇要上傳的檔案</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1782"/>
-        <location filename="../src/common/utils.cpp" line="153"/>
+        <location filename="../src/main/mainwindow.cpp" line="1768"/>
+        <location filename="../src/common/utils.cpp" line="161"/>
         <source>Upload</source>
         <translation>上傳</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1845"/>
-        <location filename="../src/common/utils.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1831"/>
+        <location filename="../src/common/utils.cpp" line="135"/>
         <source>Select a directory to save the file</source>
         <translation>選擇檔案儲存路徑</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="403"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="621"/>
-        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/main/service.cpp" line="396"/>
+        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
+        <location filename="../src/common/utils.cpp" line="262"/>
         <source>please set another one.</source>
         <translation>請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="173"/>
-        <location filename="../src/common/utils.cpp" line="207"/>
+        <location filename="../src/common/utils.cpp" line="181"/>
+        <location filename="../src/common/utils.cpp" line="215"/>
         <source>Close this terminal?</source>
         <translation>關閉此終端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="174"/>
-        <location filename="../src/common/utils.cpp" line="208"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>該終端中仍然有1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="178"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="186"/>
+        <location filename="../src/common/utils.cpp" line="220"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>該終端中仍然有%1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="203"/>
+        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="211"/>
         <source>Close this window?</source>
         <translation>關閉這個窗口？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="184"/>
-        <location filename="../src/common/utils.cpp" line="204"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>窗口內一些終端仍然有進程在運行，關閉窗口會殺死所有進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Programs are still running in terminal</source>
         <translation>多個程式仍在執行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="221"/>
+        <location filename="../src/common/utils.cpp" line="229"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>您確定要卸載它嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="234"/>
-        <location filename="../src/common/utils.cpp" line="238"/>
+        <location filename="../src/common/utils.cpp" line="242"/>
+        <location filename="../src/common/utils.cpp" line="246"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您確定要卸載終端嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="235"/>
-        <location filename="../src/common/utils.cpp" line="239"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸載後將無法再使用該應用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="245"/>
-        <location filename="../src/common/utils.cpp" line="289"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
+        <location filename="../src/common/utils.cpp" line="297"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="323"/>
+        <location filename="../src/common/utils.cpp" line="331"/>
         <source>Set the work directory</source>
         <translation>設定終端機的啟動目錄</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="326"/>
+        <location filename="../src/common/utils.cpp" line="334"/>
         <source>Set the window mode on starting</source>
         <translation>設置終端開啟的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="329"/>
+        <location filename="../src/common/utils.cpp" line="337"/>
         <source>Execute a command in the terminal</source>
         <translation>於終端機執行程式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
+        <location filename="../src/common/utils.cpp" line="340"/>
         <source>Run script string in the terminal</source>
         <translation>在終端中允許腳本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
+        <location filename="../src/common/utils.cpp" line="343"/>
         <source>Run in quake mode</source>
         <translation>以雷神模式執行終端機</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
+        <location filename="../src/common/utils.cpp" line="346"/>
         <source>Keep terminal open when command finishes</source>
         <translation>設置終端顯示命令或腳本執行後的結果</translation>
     </message>
@@ -800,12 +809,12 @@
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="201"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="186"/>
         <source>Add Server</source>
         <translation>加入伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="205"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="190"/>
         <source>No servers yet</source>
         <translation>未添加伺服器</translation>
     </message>
@@ -813,12 +822,12 @@
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="90"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
         <translation>遠端管理</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="216"/>
+        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
         <translation>使用右鍵點擊上傳和下載檔案前，請確認伺服器已安裝 rz 和 sz 指令。</translation>
     </message>
@@ -826,7 +835,7 @@
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="225"/>
+        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="210"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -834,137 +843,137 @@
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="70"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="55"/>
         <source>Advanced options</source>
         <translation>進階選項</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="108"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="93"/>
         <source>Add Server</source>
         <translation>加入伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
         <source>Server name:</source>
         <translation>伺服器名稱：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="156"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="184"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="131"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="169"/>
         <source>Required</source>
         <translation>必須</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="154"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
         <source>Address:</source>
         <translation>位址：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="161"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="146"/>
         <source>Port:</source>
         <translation>通訊埠：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="182"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Username:</source>
         <translation>使用者名稱：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="174"/>
         <source>Password:</source>
         <translation>密碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="195"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="180"/>
         <source>Certificate:</source>
         <translation>憑證檔案：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="196"/>
         <source>Group:</source>
         <translation>分組：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="202"/>
         <source>Path:</source>
         <translation>位置：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="208"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="214"/>
         <source>Encoding:</source>
         <translation>編碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="235"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="220"/>
         <source>Backspace key:</source>
         <translation>退格鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="241"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="226"/>
         <source>Delete key:</source>
         <translation>刪除鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="232"/>
         <source>Delete server</source>
         <translation>刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="261"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="262"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="247"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="266"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="251"/>
         <source>Edit Server</source>
         <translation>編輯伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="267"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="252"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>儲 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="511"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Please enter a server name</source>
         <translation>請輸入伺服器名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="524"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>Please enter an IP address</source>
         <translation>請輸入IP位址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="529"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="514"/>
         <source>Please enter a port</source>
         <translation>請輸入埠</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="520"/>
         <source>Please enter a username</source>
         <translation>請輸入使用者名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="549"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="534"/>
         <source>The server name already exists,</source>
         <translation>該伺服器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="550"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="535"/>
         <source>please input another one. </source>
         <translation>請重新輸入</translation>
     </message>
@@ -972,7 +981,7 @@
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="399"/>
+        <location filename="../src/main/service.cpp" line="392"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -981,38 +990,48 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Normal window</source>
         <translation>正常視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最⼤化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="143"/>
+        <location filename="../src/settings/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="718"/>
+        <source>Fast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settings.cpp" line="723"/>
+        <source>Slow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="283"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="292"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
         <translation>%1為無效快捷鍵，</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="299"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="306"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="312"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
+        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
         <translation>快捷鍵%1已被占用，</translation>
     </message>
@@ -1020,55 +1039,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="60"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="44"/>
         <source>Insert</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>username: %u</source>
         <translation>使用者名稱：%u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>username@: %U</source>
         <translation>使用者名稱@：%U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="79"/>
         <source>remote host: %h</source>
         <translation>遠端主機：%h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>session number: %#</source>
         <translation>工作階段編號：%#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="80"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
         <source>title set by shell: %w</source>
         <translation>shell設定的視窗標題：%w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>program name: %n</source>
         <translation>程式名：%n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="107"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="91"/>
         <source>current directory (short): %d</source>
         <translation>目前目錄（短）：%d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="108"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="92"/>
         <source>current directory (long): %D</source>
         <translation>目前目錄（長）：%D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="109"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
         <source>local host: %h</source>
         <translation>本機主機：%h</translation>
     </message>
@@ -1076,90 +1095,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="483"/>
+        <location filename="../src/views/termwidget.cpp" line="473"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="476"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="495"/>
+        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open</source>
         <translation>開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open in file manager</source>
         <translation>在檔案管理器中開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="498"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Horizontal split</source>
         <translation>水平分割</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="511"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="501"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Vertical split</source>
         <translation>垂直分割</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
-        <location filename="../src/views/termwidget.cpp" line="567"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>New tab</source>
         <translation>建立標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="518"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="530"/>
+        <location filename="../src/views/termwidget.cpp" line="520"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
+        <location filename="../src/views/termwidget.cpp" line="523"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
+        <location filename="../src/views/termwidget.cpp" line="539"/>
         <source>Custom commands</source>
         <translation>自訂命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="551"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Remote management</source>
         <translation>遠端管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="555"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Upload file</source>
         <translation>上傳檔案</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="546"/>
         <source>Download file</source>
         <translation>下載檔案</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="561"/>
+        <location filename="../src/views/termwidget.cpp" line="551"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -1167,21 +1186,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="189"/>
-        <location filename="../src/common/utils.cpp" line="223"/>
+        <location filename="../src/common/utils.cpp" line="197"/>
+        <location filename="../src/common/utils.cpp" line="231"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
+        <location filename="../src/common/utils.cpp" line="199"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>離 開</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="224"/>
-        <location filename="../src/common/utils.cpp" line="256"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
+        <location filename="../src/common/utils.cpp" line="264"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>


### PR DESCRIPTION
Description: 当前终端版本特性仅用部分符号作为长字符串的分隔符号且无法调整，无法应对用户在使用双击复制选中文本时灵活的使用场景。本次提交提供在终端设置选项里面自定义双击选中时分隔符。

Log:  终端设置增加在双击选中区域包含特殊符号选项

效果如下：
![image](https://user-images.githubusercontent.com/28835628/232379105-bcd8f61e-899a-4db2-87bd-fa191d872cd9.png)



