### PR TITLE
fix: Remove useless desktop environment variable

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -28,9 +28,6 @@ DCORE_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
-    if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
-        setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);
-    }
     // 应用计时
     QTime useTime;
     useTime.start();


### PR DESCRIPTION
Avoid setting XDG_CURRENT_DESKTOP to "Deepin" which is a useless behaviour.

Log: Remove useless desktop environment variable