### PR TITLE
fix: 尝试修复禁用Flowcontrol后，拦截Ctrl+S/Q快捷键的问题

### DIFF
--- a/3rdparty/terminalwidget/lib/Session.cpp
+++ b/3rdparty/terminalwidget/lib/Session.cpp
@@ -954,7 +954,7 @@ void Session::setFlowControlEnabled(bool enabled)
 }
 bool Session::flowControlEnabled() const
 {
-    return _flowControl;
+    return _shellProcess->flowControlEnabled();
 }
 //void Session::fireZModemDetected()
 //{

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -409,7 +409,7 @@
                             "default": "$SHELL"
                         },
                         {
-                            "key": "enable_ctrl_flow",
+                            "key": "disable_ctrl_flow",
                             "text": "Disable flow control using Ctrl+S, Ctrl+Q",
                             "type": "checkbox",
                             "default": "false"

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -1474,17 +1474,15 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
         }
         /********************* Modify by ut000610 daizhengwen End ************************/
         if ((Qt::ControlModifier == keyEvent->modifiers()) && (Qt::Key_S == keyEvent->key())) {
-            if (!Settings::instance()->enableControlFlow())
-                return true;
 
             assert(term);
-            if (term->isActiveWindow())
+            if (term->isActiveWindow() && term->flowControlEnabled())
                 term->showFlowMessage(true);
         }
 
         if ((Qt::ControlModifier == keyEvent->modifiers()) && (Qt::Key_Q == keyEvent->key())) {
             assert(term);
-            if (term->isActiveWindow())
+            if (term->isActiveWindow() && term->flowControlEnabled())
                 term->showFlowMessage(false);
         }
     }

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -286,7 +286,7 @@ void Settings::initConnection()
 {
     connect(settings, &Dtk::Core::DSettings::valueChanged, this, [ = ](const QString & key, const QVariant & value) {
         Q_UNUSED(value)
-        if (key.contains("basic.interface.") || key.contains("advanced.cursor.") || key.contains("advanced.scroll."))
+        if (key.contains("basic.interface.") || key.contains("advanced.cursor.") || key.contains("advanced.scroll.") || key.contains("advanced.shell."))
             emit terminalSettingChanged(key);
         else if (key.contains("shortcuts."))
             emit shortcutSettingChanged(key);
@@ -609,9 +609,9 @@ void Settings::handleWidthFont()
 }
 
 
-bool Settings::enableControlFlow(void)
+bool Settings::disableControlFlow(void)
 {
-    return !settings->option("advanced.shell.enable_ctrl_flow")->value().toBool();
+    return settings->option("advanced.shell.disable_ctrl_flow")->value().toBool();
 }
 
 /******** Add by ut001000 renfeixiang 2020-06-15:增加 每次显示设置界面时，更新设置的等宽字体 End***************/

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -207,7 +207,7 @@ public:
      * @author 朱科伟
      * @return
      */
-    bool enableControlFlow(void);
+    bool disableControlFlow(void);
     /**
      * @brief 历史记录行数
      * @author Archie Meng

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -156,6 +156,8 @@ TermWidget::TermWidget(const TermProperties &properties, QWidget *parent) : QTer
 
     setFocusPolicy(Qt::NoFocus);
 
+    setFlowControlEnabled(!Settings::instance()->disableControlFlow());
+
     TermWidgetPage *parentPage = qobject_cast<TermWidgetPage *>(parent);
     //qInfo() << parentPage << endl;
     connect(this, &QTermWidget::uninstallTerminal, parentPage, &TermWidgetPage::uninstallTerminal);
@@ -1125,6 +1127,11 @@ void TermWidget::onSettingValueChanged(const QString &keyName)
     
     if ("advanced.cursor.include_special_characters_in_double_click_selections" == keyName) {
         setTerminalWordCharacters(Settings::instance()->wordCharacters());
+        return;
+    }
+
+    if ("advanced.shell.disable_ctrl_flow" == keyName) {
+        setFlowControlEnabled(!Settings::instance()->disableControlFlow());
         return;
     }
 


### PR DESCRIPTION
底层三方库使用了错误的控制流判断方式。修改为直接读取状态后解决。

Bug: https://github.com/linuxdeepin/developer-center/issues/4612
Log: 尝试修复禁用Flowcontrol后，拦截Ctrl+S/Q快捷键的问题