### PR TITLE
fix: 给编辑服务器对话框中‘分组’为空值时添加提示语

### DIFF
--- a/src/remotemanage/serverconfigoptdlg.cpp
+++ b/src/remotemanage/serverconfigoptdlg.cpp
@@ -186,6 +186,7 @@ void ServerConfigOptDlg::initUI()
     setLabelStyle(pGroupLabel);
     m_pGridLayout->addWidget(pGroupLabel, 6, 0);
     m_group->setEditable(true);
+    m_group->lineEdit()->setPlaceholderText(tr("No Group"));
     m_pGridLayout->addWidget(m_group, 6, 1, 1, 3);
 
     //pPathLabel

--- a/translations/deepin-terminal_zh_CN.ts
+++ b/translations/deepin-terminal_zh_CN.ts
@@ -268,12 +268,12 @@
         <translation>关 闭</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1818"/>
+        <location filename="../src/main/mainwindow.cpp" line="1819"/>
         <source>Type path to download file</source>
         <translation>请输入下载文件的路径</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2124"/>
+        <location filename="../src/main/mainwindow.cpp" line="2125"/>
         <source>Custom Theme</source>
         <translation>自定义主题</translation>
     </message>
@@ -284,7 +284,7 @@
         <location filename="../src/views/listview.cpp" line="485"/>
         <location filename="../src/views/listview.cpp" line="870"/>
         <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
-        <location filename="../src/common/utils.cpp" line="252"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
@@ -303,68 +303,68 @@
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="505"/>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="508"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close workspace</source>
         <translation>关闭工作区</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close other workspaces</source>
         <translation>关闭其他工作区</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1181"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 “%1”，已启动“%2”代替。请检查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1179"/>
+        <location filename="../src/views/termwidget.cpp" line="1187"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不开“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1181"/>
+        <location filename="../src/views/termwidget.cpp" line="1189"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1224"/>
+        <location filename="../src/views/termwidget.cpp" line="1232"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已经按下Ctrl+S，输出被挂起。可以按下Ctrl+Q继续。</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Tab title format</source>
         <translation>标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <source>Remote tab title format</source>
         <translation>远程标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
-        <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/views/tabbar.cpp" line="490"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Rename title</source>
         <translation>重命名标题</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="483"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="484"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close tab</source>
         <translation>关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="486"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="487"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close other tabs</source>
         <translation>关闭其他标签页</translation>
     </message>
@@ -394,338 +394,340 @@
         <translation>输出时滚动</translation>
     </message>
     <message>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation type="vanished">允许Ctrl+滑动滚轮缩放文本大小</translation>
+        <translation>允许Ctrl+滑动滚轮缩放文本大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="27"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Hide Quake window after losing focus</source>
         <translation>丢失焦点后隐藏雷神窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <source>Quake window animation speed</source>
         <translation>雷神窗口动画速度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <location filename="../src/main/service.cpp" line="142"/>
         <source>Blur background</source>
         <translation>背景模糊</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Use on starting</source>
         <translation>启动时使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font</source>
         <translation>字体</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <source>Font size</source>
         <translation>字体大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <location filename="../src/main/service.cpp" line="165"/>
         <source>Opacity</source>
         <translation>透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Cursor</source>
         <translation>光标</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Basic</source>
         <translation>基础设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Interface</source>
         <translation>界面</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
-        <location filename="../src/main/mainwindow.cpp" line="1660"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/mainwindow.cpp" line="1661"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
+        <location filename="../src/main/mainwindow.cpp" line="1659"/>
+        <location filename="../src/main/mainwindow.cpp" line="2513"/>
         <source>Terminal</source>
         <translation>终端</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <source>Workspace</source>
         <translation>工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Default size</source>
         <translation>默认大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to next command</source>
         <translation>跳转到下一个命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <source>Jump to previous command</source>
         <translation>跳转到上一个命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom out</source>
         <translation>缩小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <source>Close other windows</source>
         <translation>关闭其他窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <source>Close window</source>
         <translation>关闭窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Next tab</source>
         <translation>下一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Previous tab</source>
         <translation>上一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select left workspace</source>
         <translation>选择左边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select lower workspace</source>
         <translation>选择下面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select right workspace</source>
         <translation>选择右边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select upper workspace</source>
         <translation>选择上面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab titles</source>
         <translation>标签标题</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 1</source>
         <translation>切换到标签 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 2</source>
         <translation>切换到标签 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 3</source>
         <translation>切换到标签 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 4</source>
         <translation>切换到标签 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 5</source>
         <translation>切换到标签 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 6</source>
         <translation>切换到标签 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 7</source>
         <translation>切换到标签 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 8</source>
         <translation>切换到标签 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 9</source>
         <translation>切换到标签 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
         <source>History size</source>
         <translation>历史回滚行数</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <location filename="../src/settings/settings_translation.cpp" line="149"/>
         <source>Include special character(s) in double click selections</source>
         <translation>在双击选中区域包含特殊符号</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="429"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="430"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>名称长度不得超过32个字符</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="495"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Select the private key file</source>
         <translation>选择私钥文件</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="499"/>
-        <location filename="../src/main/mainwindow.cpp" line="1840"/>
-        <location filename="../src/common/utils.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="500"/>
+        <location filename="../src/main/mainwindow.cpp" line="1841"/>
+        <location filename="../src/common/utils.cpp" line="142"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
@@ -735,131 +737,131 @@
         <translation>终端是一款集工作区、多窗口、远程管理、雷神模式等功能的高级终端模拟器。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1656"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Tabs</source>
         <translation>标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1676"/>
+        <location filename="../src/main/mainwindow.cpp" line="1677"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光标焦点切换至“+”图标</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select tab</source>
         <translation>选择标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1764"/>
-        <location filename="../src/common/utils.cpp" line="156"/>
+        <location filename="../src/main/mainwindow.cpp" line="1765"/>
+        <location filename="../src/common/utils.cpp" line="157"/>
         <source>Select file to upload</source>
         <translation>选择要上传的文件</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1771"/>
-        <location filename="../src/common/utils.cpp" line="161"/>
+        <location filename="../src/main/mainwindow.cpp" line="1772"/>
+        <location filename="../src/common/utils.cpp" line="162"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1834"/>
-        <location filename="../src/common/utils.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1835"/>
+        <location filename="../src/common/utils.cpp" line="136"/>
         <source>Select a directory to save the file</source>
         <translation>选择下载文件的保存目录</translation>
     </message>
     <message>
         <location filename="../src/main/service.cpp" line="355"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
-        <location filename="../src/common/utils.cpp" line="262"/>
+        <location filename="../src/common/utils.cpp" line="263"/>
         <source>please set another one.</source>
         <translation>请重新设置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="215"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>Close this terminal?</source>
         <translation>关闭此终端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="216"/>
+        <location filename="../src/common/utils.cpp" line="183"/>
+        <location filename="../src/common/utils.cpp" line="217"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>该终端中仍然有1个进程在运行，关闭终端将杀死进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="186"/>
-        <location filename="../src/common/utils.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="187"/>
+        <location filename="../src/common/utils.cpp" line="221"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>该终端中仍然有%1个进程在运行，关闭终端将杀死进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
-        <location filename="../src/common/utils.cpp" line="211"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>Close this window?</source>
         <translation>关闭这个窗口？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="192"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="193"/>
+        <location filename="../src/common/utils.cpp" line="213"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>窗口内一些终端仍然有进程在运行，关闭窗口会杀死所有进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Programs are still running in terminal</source>
         <translation>终端仍然有程序在运行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>您确定要卸载它吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="242"/>
-        <location filename="../src/common/utils.cpp" line="246"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您确定要卸载终端吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="243"/>
-        <location filename="../src/common/utils.cpp" line="247"/>
+        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/common/utils.cpp" line="248"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸载后将无法再使用该应用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="253"/>
-        <location filename="../src/common/utils.cpp" line="297"/>
+        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/common/utils.cpp" line="298"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="331"/>
+        <location filename="../src/common/utils.cpp" line="332"/>
         <source>Set the work directory</source>
         <translation>设置终端的启动目录</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="334"/>
+        <location filename="../src/common/utils.cpp" line="335"/>
         <source>Set the window mode on starting</source>
         <translation>设置终端开启的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="338"/>
         <source>Execute a command in the terminal</source>
         <translation>在终端中运行⼀个程序</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="341"/>
         <source>Run script string in the terminal</source>
         <translation>在终端中允许脚本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="343"/>
+        <location filename="../src/common/utils.cpp" line="344"/>
         <source>Run in quake mode</source>
         <translation>设置终端以雷神模式启动</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="346"/>
+        <location filename="../src/common/utils.cpp" line="347"/>
         <source>Keep terminal open when command finishes</source>
         <translation>设置终端显示命令或脚本执行后的结果</translation>
     </message>
@@ -970,27 +972,32 @@
         <translation>分组：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="192"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <source>No Group</source>
+        <translation>无分组</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="193"/>
         <source>Path:</source>
         <translation>路径：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="198"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="199"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="204"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="205"/>
         <source>Encoding:</source>
         <translation>编码：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="210"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
         <source>Backspace key:</source>
         <translation>退格键：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="216"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
         <source>Delete key:</source>
         <translation>删除键：</translation>
     </message>
@@ -999,55 +1006,55 @@
         <translation type="vanished">删除服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="224"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="227"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
         <source>Edit Server</source>
         <translation>编辑服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>保 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="423"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="424"/>
         <source>Please enter a server name</source>
         <translation>请输入服务器名称</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="436"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="437"/>
         <source>Please enter an IP address</source>
         <translation>请输入IP地址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="441"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="442"/>
         <source>Please enter a port</source>
         <translation>请输入端口</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="447"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="448"/>
         <source>Please enter a username</source>
         <translation>请输入用户名</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="461"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
         <source>The server name already exists,</source>
         <translation>该服务器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="463"/>
         <source>please input another one. </source>
         <translation>请重新输入</translation>
     </message>
@@ -1064,32 +1071,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Normal window</source>
         <translation>正常窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Maximum</source>
         <translation>最大化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="718"/>
+        <location filename="../src/settings/settings.cpp" line="721"/>
         <source>Fast</source>
         <translation>快</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="723"/>
+        <location filename="../src/settings/settings.cpp" line="726"/>
         <source>Slow</source>
         <translation>慢</translation>
     </message>
@@ -1169,90 +1176,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="474"/>
+        <location filename="../src/views/termwidget.cpp" line="477"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="477"/>
+        <location filename="../src/views/termwidget.cpp" line="480"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
+        <location filename="../src/views/termwidget.cpp" line="493"/>
         <source>Open in file manager</source>
         <translation>在文件管理器中打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="502"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="502"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="505"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="512"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="515"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="519"/>
+        <location filename="../src/views/termwidget.cpp" line="522"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
+        <location filename="../src/views/termwidget.cpp" line="524"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="524"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="531"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="538"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Encoding</source>
         <translation>编码</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="540"/>
+        <location filename="../src/views/termwidget.cpp" line="543"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="542"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="546"/>
+        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>Upload file</source>
         <translation>上传文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="550"/>
         <source>Download file</source>
         <translation>下载文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="552"/>
+        <location filename="../src/views/termwidget.cpp" line="555"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
@@ -1260,21 +1267,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="197"/>
-        <location filename="../src/common/utils.cpp" line="231"/>
+        <location filename="../src/common/utils.cpp" line="198"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="199"/>
+        <location filename="../src/common/utils.cpp" line="200"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>关 闭</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="232"/>
-        <location filename="../src/common/utils.cpp" line="264"/>
+        <location filename="../src/common/utils.cpp" line="233"/>
+        <location filename="../src/common/utils.cpp" line="265"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>

--- a/translations/deepin-terminal_zh_HK.ts
+++ b/translations/deepin-terminal_zh_HK.ts
@@ -268,12 +268,12 @@
         <translation>關 閉</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1818"/>
+        <location filename="../src/main/mainwindow.cpp" line="1819"/>
         <source>Type path to download file</source>
         <translation>請輸入下載文件的路徑</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2124"/>
+        <location filename="../src/main/mainwindow.cpp" line="2125"/>
         <source>Custom Theme</source>
         <translation>自定義主題</translation>
     </message>
@@ -284,7 +284,7 @@
         <location filename="../src/views/listview.cpp" line="485"/>
         <location filename="../src/views/listview.cpp" line="870"/>
         <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
-        <location filename="../src/common/utils.cpp" line="252"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
@@ -303,68 +303,68 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="505"/>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="508"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close workspace</source>
         <translation>關閉工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close other workspaces</source>
         <translation>關閉其他工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1181"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 「%1」，已啟動「%2」代替。請檢查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1179"/>
+        <location filename="../src/views/termwidget.cpp" line="1187"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不開“%1”，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1181"/>
+        <location filename="../src/views/termwidget.cpp" line="1189"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到「%1」，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1224"/>
+        <location filename="../src/views/termwidget.cpp" line="1232"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已經按下Ctrl+S，輸出被掛起。可以按下Ctrl+Q繼續。</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Tab title format</source>
         <translation>標籤標題格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <source>Remote tab title format</source>
         <translation>遠程標籤標題格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
-        <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/views/tabbar.cpp" line="490"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Rename title</source>
         <translation>重命名標題</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="483"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="484"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="486"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="487"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
@@ -394,338 +394,340 @@
         <translation>輸出時滾動</translation>
     </message>
     <message>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation type="vanished">允許Ctrl+滑動滾輪縮放文字大小</translation>
+        <translation>允許Ctrl+滑動滾輪縮放文字大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="27"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Hide Quake window after losing focus</source>
         <translation>丟失焦點後隱藏雷神視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <source>Quake window animation speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <location filename="../src/main/service.cpp" line="142"/>
         <source>Blur background</source>
         <translation>背景模糊</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Use on starting</source>
         <translation>啟動時使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font</source>
         <translation>字體</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <source>Font size</source>
         <translation>字體大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <location filename="../src/main/service.cpp" line="165"/>
         <source>Opacity</source>
         <translation>透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Cursor</source>
         <translation>鼠標</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Scroll</source>
         <translation>滑鼠滾輪</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
-        <location filename="../src/main/mainwindow.cpp" line="1660"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/mainwindow.cpp" line="1661"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
+        <location filename="../src/main/mainwindow.cpp" line="1659"/>
+        <location filename="../src/main/mainwindow.cpp" line="2513"/>
         <source>Terminal</source>
         <translation>終端</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <source>Workspace</source>
         <translation>工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Custom commands</source>
         <translation>自定義命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Remote management</source>
         <translation>遠程管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Default size</source>
         <translation>默認大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Select all</source>
         <translation>選擇全部</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to next command</source>
         <translation>跳轉到下一個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <source>Jump to previous command</source>
         <translation>跳轉到上一個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom in</source>
         <translation>拉近</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom out</source>
         <translation>拉遠</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <source>Close other windows</source>
         <translation>關閉其他視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <source>Close window</source>
         <translation>關閉視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Horizontal split</source>
         <translation>橫向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>New tab</source>
         <translation>新建標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select left workspace</source>
         <translation>選擇左邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select lower workspace</source>
         <translation>選擇下面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select right workspace</source>
         <translation>選擇右邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select upper workspace</source>
         <translation>選擇上面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Vertical split</source>
         <translation>縱向分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab titles</source>
         <translation>標籤標題</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 1</source>
         <translation>切換到標籤 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 2</source>
         <translation>切換到標籤 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 3</source>
         <translation>切換到標籤 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 4</source>
         <translation>切換到標籤 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 5</source>
         <translation>切換到標籤 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 6</source>
         <translation>切換到標籤 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 7</source>
         <translation>切換到標籤 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 8</source>
         <translation>切換到標籤 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 9</source>
         <translation>切換到標籤 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
         <source>History size</source>
         <translation>歷史回滾行數</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <location filename="../src/settings/settings_translation.cpp" line="149"/>
         <source>Include special character(s) in double click selections</source>
         <translation>在雙擊選中區域包含特殊符號</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="429"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="430"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>名稱長度不得超過32個字符</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="495"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Select the private key file</source>
         <translation>選擇私鑰文件</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="499"/>
-        <location filename="../src/main/mainwindow.cpp" line="1840"/>
-        <location filename="../src/common/utils.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="500"/>
+        <location filename="../src/main/mainwindow.cpp" line="1841"/>
+        <location filename="../src/common/utils.cpp" line="142"/>
         <source>Select</source>
         <translation>選擇</translation>
     </message>
@@ -735,131 +737,131 @@
         <translation>終端是⼀款集⼯作區、多視窗、遠程管理、雷神模式等功能的⾼級終端模擬器。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1656"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Tabs</source>
         <translation>標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1676"/>
+        <location filename="../src/main/mainwindow.cpp" line="1677"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光標焦點切換至「+」圖標</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select tab</source>
         <translation>選擇標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1764"/>
-        <location filename="../src/common/utils.cpp" line="156"/>
+        <location filename="../src/main/mainwindow.cpp" line="1765"/>
+        <location filename="../src/common/utils.cpp" line="157"/>
         <source>Select file to upload</source>
         <translation>選擇要上傳的文件</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1771"/>
-        <location filename="../src/common/utils.cpp" line="161"/>
+        <location filename="../src/main/mainwindow.cpp" line="1772"/>
+        <location filename="../src/common/utils.cpp" line="162"/>
         <source>Upload</source>
         <translation>上傳</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1834"/>
-        <location filename="../src/common/utils.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1835"/>
+        <location filename="../src/common/utils.cpp" line="136"/>
         <source>Select a directory to save the file</source>
         <translation>選擇下載文件的保存目錄</translation>
     </message>
     <message>
         <location filename="../src/main/service.cpp" line="355"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
-        <location filename="../src/common/utils.cpp" line="262"/>
+        <location filename="../src/common/utils.cpp" line="263"/>
         <source>please set another one.</source>
         <translation>請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="215"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>Close this terminal?</source>
         <translation>關閉此終端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="216"/>
+        <location filename="../src/common/utils.cpp" line="183"/>
+        <location filename="../src/common/utils.cpp" line="217"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>該終端中仍然有1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="186"/>
-        <location filename="../src/common/utils.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="187"/>
+        <location filename="../src/common/utils.cpp" line="221"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>該終端中仍然有%1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
-        <location filename="../src/common/utils.cpp" line="211"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>Close this window?</source>
         <translation>關閉這個視窗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="192"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="193"/>
+        <location filename="../src/common/utils.cpp" line="213"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>視窗內一些終端仍然有進程在運行，關閉視窗會殺死所有進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Programs are still running in terminal</source>
         <translation>終端仍然有程序在運行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>你確定要解除安裝嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="242"/>
-        <location filename="../src/common/utils.cpp" line="246"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您確定要卸載終端嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="243"/>
-        <location filename="../src/common/utils.cpp" line="247"/>
+        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/common/utils.cpp" line="248"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸載後將無法再使用該應用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="253"/>
-        <location filename="../src/common/utils.cpp" line="297"/>
+        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/common/utils.cpp" line="298"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="331"/>
+        <location filename="../src/common/utils.cpp" line="332"/>
         <source>Set the work directory</source>
         <translation>設置終端的啟動目錄</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="334"/>
+        <location filename="../src/common/utils.cpp" line="335"/>
         <source>Set the window mode on starting</source>
         <translation>設置終端開啟的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="338"/>
         <source>Execute a command in the terminal</source>
         <translation>在終端運行一個程序</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="341"/>
         <source>Run script string in the terminal</source>
         <translation>在終端中允許腳本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="343"/>
+        <location filename="../src/common/utils.cpp" line="344"/>
         <source>Run in quake mode</source>
         <translation>雷神模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="346"/>
+        <location filename="../src/common/utils.cpp" line="347"/>
         <source>Keep terminal open when command finishes</source>
         <translation>設置終端顯示命令或腳本執行後的結果</translation>
     </message>
@@ -970,27 +972,32 @@
         <translation>分組：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="192"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <source>No Group</source>
+        <translation>無分組</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="193"/>
         <source>Path:</source>
         <translation>路徑：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="198"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="199"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="204"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="205"/>
         <source>Encoding:</source>
         <translation>編碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="210"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
         <source>Backspace key:</source>
         <translation>退格鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="216"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
         <source>Delete key:</source>
         <translation>刪除鍵：</translation>
     </message>
@@ -999,55 +1006,55 @@
         <translation type="vanished">刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="224"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="227"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
         <source>Edit Server</source>
         <translation>編輯伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>保 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="423"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="424"/>
         <source>Please enter a server name</source>
         <translation>請輸入伺服器名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="436"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="437"/>
         <source>Please enter an IP address</source>
         <translation>請輸入IP位址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="441"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="442"/>
         <source>Please enter a port</source>
         <translation>請輸入端口</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="447"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="448"/>
         <source>Please enter a username</source>
         <translation>請輸入用戶名</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="461"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
         <source>The server name already exists,</source>
         <translation>該伺服器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="463"/>
         <source>please input another one. </source>
         <translation>請重新輸入</translation>
     </message>
@@ -1064,32 +1071,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Normal window</source>
         <translation>正常視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Maximum</source>
         <translation>最⼤化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="718"/>
+        <location filename="../src/settings/settings.cpp" line="721"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="723"/>
+        <location filename="../src/settings/settings.cpp" line="726"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1169,90 +1176,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="474"/>
+        <location filename="../src/views/termwidget.cpp" line="477"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="477"/>
+        <location filename="../src/views/termwidget.cpp" line="480"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open</source>
         <translation>開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
+        <location filename="../src/views/termwidget.cpp" line="493"/>
         <source>Open in file manager</source>
         <translation>在文件管理器中打開</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="502"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Horizontal split</source>
         <translation>橫向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="502"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="505"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Vertical split</source>
         <translation>縱向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="512"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="515"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>New tab</source>
         <translation>新建標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="519"/>
+        <location filename="../src/views/termwidget.cpp" line="522"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
+        <location filename="../src/views/termwidget.cpp" line="524"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="524"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="531"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="538"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="540"/>
+        <location filename="../src/views/termwidget.cpp" line="543"/>
         <source>Custom commands</source>
         <translation>自定義命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="542"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Remote management</source>
         <translation>遠程管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="546"/>
+        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>Upload file</source>
         <translation>上傳文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="550"/>
         <source>Download file</source>
         <translation>下載文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="552"/>
+        <location filename="../src/views/termwidget.cpp" line="555"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
@@ -1260,21 +1267,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="197"/>
-        <location filename="../src/common/utils.cpp" line="231"/>
+        <location filename="../src/common/utils.cpp" line="198"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="199"/>
+        <location filename="../src/common/utils.cpp" line="200"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>關 閉</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="232"/>
-        <location filename="../src/common/utils.cpp" line="264"/>
+        <location filename="../src/common/utils.cpp" line="233"/>
+        <location filename="../src/common/utils.cpp" line="265"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>

--- a/translations/deepin-terminal_zh_TW.ts
+++ b/translations/deepin-terminal_zh_TW.ts
@@ -268,12 +268,12 @@
         <translation>離 開</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1818"/>
+        <location filename="../src/main/mainwindow.cpp" line="1819"/>
         <source>Type path to download file</source>
         <translation>輸入位置以下載檔案</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2124"/>
+        <location filename="../src/main/mainwindow.cpp" line="2125"/>
         <source>Custom Theme</source>
         <translation>自訂主題</translation>
     </message>
@@ -284,7 +284,7 @@
         <location filename="../src/views/listview.cpp" line="485"/>
         <location filename="../src/views/listview.cpp" line="870"/>
         <location filename="../src/views/tabrenamedlg.cpp" line="220"/>
-        <location filename="../src/common/utils.cpp" line="252"/>
+        <location filename="../src/common/utils.cpp" line="253"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
@@ -303,68 +303,68 @@
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="505"/>
-        <location filename="../src/settings/settings_translation.cpp" line="95"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="508"/>
+        <location filename="../src/settings/settings_translation.cpp" line="97"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close workspace</source>
         <translation>關閉工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="508"/>
-        <location filename="../src/settings/settings_translation.cpp" line="91"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/views/termwidget.cpp" line="511"/>
+        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Close other workspaces</source>
         <translation>關閉其他工作區</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1173"/>
+        <location filename="../src/views/termwidget.cpp" line="1181"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 「%1」，已啟動「%2」代替。請檢查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1179"/>
+        <location filename="../src/views/termwidget.cpp" line="1187"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不開“%1”，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1181"/>
+        <location filename="../src/views/termwidget.cpp" line="1189"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到「%1」，無法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1224"/>
+        <location filename="../src/views/termwidget.cpp" line="1232"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已經按下Ctrl+S，輸出被掛起。可以按下Ctrl+Q繼續。</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="116"/>
-        <location filename="../src/settings/settings_translation.cpp" line="119"/>
+        <location filename="../src/settings/settings_translation.cpp" line="121"/>
         <source>Tab title format</source>
         <translation>標籤標題格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamewidget.cpp" line="118"/>
-        <location filename="../src/settings/settings_translation.cpp" line="121"/>
+        <location filename="../src/settings/settings_translation.cpp" line="123"/>
         <source>Remote tab title format</source>
         <translation>遠端標籤標題格式</translation>
     </message>
     <message>
         <location filename="../src/views/tabrenamedlg.cpp" line="187"/>
-        <location filename="../src/views/tabbar.cpp" line="489"/>
-        <location filename="../src/settings/settings_translation.cpp" line="67"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/views/tabbar.cpp" line="490"/>
+        <location filename="../src/settings/settings_translation.cpp" line="69"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Rename title</source>
         <translation>重命名分頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="483"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="484"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/tabbar.cpp" line="486"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/views/tabbar.cpp" line="487"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
@@ -394,338 +394,340 @@
         <translation>輸出時捲動</translation>
     </message>
     <message>
+        <location filename="../src/settings/settings_translation.cpp" line="27"/>
         <source>Allow Ctrl+scrollwheel to zoom text size</source>
-        <translation type="vanished">允許Ctrl+滑動滾輪縮放文字大小</translation>
+        <translation>允許Ctrl+滑動滾輪縮放文字大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="27"/>
+        <location filename="../src/settings/settings_translation.cpp" line="29"/>
         <source>Hide Quake window after losing focus</source>
         <translation>失去焦點時隱藏雷神視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="29"/>
+        <location filename="../src/settings/settings_translation.cpp" line="31"/>
         <source>Quake window animation speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="31"/>
+        <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <location filename="../src/main/service.cpp" line="142"/>
         <source>Blur background</source>
         <translation>模糊背景</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="33"/>
+        <location filename="../src/settings/settings_translation.cpp" line="35"/>
         <source>Use on starting</source>
         <translation>啟動時使用</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="35"/>
+        <location filename="../src/settings/settings_translation.cpp" line="37"/>
         <source>Font</source>
         <translation>字型</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="37"/>
+        <location filename="../src/settings/settings_translation.cpp" line="39"/>
         <source>Font size</source>
         <translation>字型大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="39"/>
+        <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <location filename="../src/main/service.cpp" line="165"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="41"/>
+        <location filename="../src/settings/settings_translation.cpp" line="43"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="43"/>
+        <location filename="../src/settings/settings_translation.cpp" line="45"/>
         <source>Cursor</source>
         <translation>游標</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="45"/>
+        <location filename="../src/settings/settings_translation.cpp" line="47"/>
         <source>Scroll</source>
         <translation>捲動</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="47"/>
+        <location filename="../src/settings/settings_translation.cpp" line="49"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="49"/>
+        <location filename="../src/settings/settings_translation.cpp" line="51"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="51"/>
+        <location filename="../src/settings/settings_translation.cpp" line="53"/>
         <source>Interface</source>
         <translation>界面</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="53"/>
+        <location filename="../src/settings/settings_translation.cpp" line="55"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="55"/>
-        <location filename="../src/main/mainwindow.cpp" line="1660"/>
+        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/main/mainwindow.cpp" line="1661"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="57"/>
+        <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <location filename="../src/main/terminalapplication.cpp" line="25"/>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
+        <location filename="../src/main/mainwindow.cpp" line="1659"/>
+        <location filename="../src/main/mainwindow.cpp" line="2513"/>
         <source>Terminal</source>
         <translation>終端機</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="59"/>
+        <location filename="../src/settings/settings_translation.cpp" line="61"/>
         <source>Workspace</source>
         <translation>工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="61"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="63"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Custom commands</source>
         <translation>自訂命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="63"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="65"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Display shortcuts</source>
         <translation>顯示快速鍵</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="65"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="67"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Remote management</source>
         <translation>遠端管理</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/main/mainwindow.cpp" line="1724"/>
+        <location filename="../src/settings/settings_translation.cpp" line="71"/>
+        <location filename="../src/main/mainwindow.cpp" line="1725"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="71"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="73"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="73"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="75"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Default size</source>
         <translation>預設大小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="75"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="77"/>
+        <location filename="../src/settings/settings_translation.cpp" line="79"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="79"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="81"/>
+        <location filename="../src/settings/settings_translation.cpp" line="83"/>
         <source>Jump to next command</source>
         <translation>跳到下個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="83"/>
+        <location filename="../src/settings/settings_translation.cpp" line="85"/>
         <source>Jump to previous command</source>
         <translation>跳到上個命令</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="85"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="87"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="87"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Zoom out</source>
         <translation>縮小</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="89"/>
+        <location filename="../src/settings/settings_translation.cpp" line="91"/>
         <source>Close other windows</source>
         <translation>關閉其他視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="93"/>
+        <location filename="../src/settings/settings_translation.cpp" line="95"/>
         <source>Close window</source>
         <translation>關閉視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="97"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="99"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Horizontal split</source>
         <translation>水平分割</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="99"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="101"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>New tab</source>
         <translation>建立標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="101"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="103"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="103"/>
-        <location filename="../src/main/mainwindow.cpp" line="1704"/>
+        <location filename="../src/settings/settings_translation.cpp" line="105"/>
+        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="105"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="107"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select left workspace</source>
         <translation>選擇左邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="107"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="109"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select lower workspace</source>
         <translation>選擇下面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="109"/>
-        <location filename="../src/main/mainwindow.cpp" line="1706"/>
+        <location filename="../src/settings/settings_translation.cpp" line="111"/>
+        <location filename="../src/main/mainwindow.cpp" line="1707"/>
         <source>Select right workspace</source>
         <translation>選擇右邊的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="111"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="113"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select upper workspace</source>
         <translation>選擇上面的工作區</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="113"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/settings/settings_translation.cpp" line="115"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Vertical split</source>
         <translation>垂直分割</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="115"/>
-        <location filename="../src/main/mainwindow.cpp" line="1689"/>
+        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/main/mainwindow.cpp" line="1690"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="117"/>
+        <location filename="../src/settings/settings_translation.cpp" line="119"/>
         <source>Tab titles</source>
         <translation>標籤標題</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="125"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 1</source>
         <translation>切換到標籤 1</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="125"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="127"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 2</source>
         <translation>切換到標籤 2</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="127"/>
-        <location filename="../src/main/mainwindow.cpp" line="1707"/>
+        <location filename="../src/settings/settings_translation.cpp" line="129"/>
+        <location filename="../src/main/mainwindow.cpp" line="1708"/>
         <source>Go to tab 3</source>
         <translation>切換到標籤 3</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="129"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="131"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 4</source>
         <translation>切換到標籤 4</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="131"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="133"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 5</source>
         <translation>切換到標籤 5</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="133"/>
-        <location filename="../src/main/mainwindow.cpp" line="1708"/>
+        <location filename="../src/settings/settings_translation.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1709"/>
         <source>Go to tab 6</source>
         <translation>切換到標籤 6</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="135"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="137"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 7</source>
         <translation>切換到標籤 7</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="137"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="139"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 8</source>
         <translation>切換到標籤 8</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="139"/>
-        <location filename="../src/main/mainwindow.cpp" line="1709"/>
+        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/main/mainwindow.cpp" line="1710"/>
         <source>Go to tab 9</source>
         <translation>切換到標籤 9</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="141"/>
+        <location filename="../src/settings/settings_translation.cpp" line="143"/>
         <source>Disable flow control using Ctrl+S, Ctrl+Q</source>
         <translation>禁用Ctrl+S和Ctrl+Q控制</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="143"/>
+        <location filename="../src/settings/settings_translation.cpp" line="145"/>
         <source>Shell profile</source>
         <translation>Shell配置</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="145"/>
+        <location filename="../src/settings/settings_translation.cpp" line="147"/>
         <source>History size</source>
         <translation>歷史回滾行數</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings_translation.cpp" line="147"/>
+        <location filename="../src/settings/settings_translation.cpp" line="149"/>
         <source>Include special character(s) in double click selections</source>
         <translation>在雙擊選中區域包含特殊符號</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="429"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="430"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="364"/>
         <source>The name should be no more than 32 characters</source>
         <translation>名稱長度不得超過32個字元</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="495"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="496"/>
         <source>Select the private key file</source>
         <translation>選擇私鑰檔案</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="499"/>
-        <location filename="../src/main/mainwindow.cpp" line="1840"/>
-        <location filename="../src/common/utils.cpp" line="141"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="500"/>
+        <location filename="../src/main/mainwindow.cpp" line="1841"/>
+        <location filename="../src/common/utils.cpp" line="142"/>
         <source>Select</source>
         <translation>選擇</translation>
     </message>
@@ -735,131 +737,131 @@
         <translation>終端機是個進階的終端模擬器，具備視窗切割、工作區、遠端管理、雷神模式等其他功能。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1656"/>
+        <location filename="../src/main/mainwindow.cpp" line="1657"/>
         <source>Tabs</source>
         <translation>標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1676"/>
+        <location filename="../src/main/mainwindow.cpp" line="1677"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光標焦點切換至「+」圖標</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
+        <location filename="../src/main/mainwindow.cpp" line="1706"/>
         <source>Select tab</source>
         <translation>選擇標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1764"/>
-        <location filename="../src/common/utils.cpp" line="156"/>
+        <location filename="../src/main/mainwindow.cpp" line="1765"/>
+        <location filename="../src/common/utils.cpp" line="157"/>
         <source>Select file to upload</source>
         <translation>選擇要上傳的檔案</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1771"/>
-        <location filename="../src/common/utils.cpp" line="161"/>
+        <location filename="../src/main/mainwindow.cpp" line="1772"/>
+        <location filename="../src/common/utils.cpp" line="162"/>
         <source>Upload</source>
         <translation>上傳</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1834"/>
-        <location filename="../src/common/utils.cpp" line="135"/>
+        <location filename="../src/main/mainwindow.cpp" line="1835"/>
+        <location filename="../src/common/utils.cpp" line="136"/>
         <source>Select a directory to save the file</source>
         <translation>選擇檔案儲存路徑</translation>
     </message>
     <message>
         <location filename="../src/main/service.cpp" line="355"/>
         <location filename="../src/customcommand/customcommandoptdlg.cpp" line="606"/>
-        <location filename="../src/common/utils.cpp" line="262"/>
+        <location filename="../src/common/utils.cpp" line="263"/>
         <source>please set another one.</source>
         <translation>請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="181"/>
-        <location filename="../src/common/utils.cpp" line="215"/>
+        <location filename="../src/common/utils.cpp" line="182"/>
+        <location filename="../src/common/utils.cpp" line="216"/>
         <source>Close this terminal?</source>
         <translation>關閉此終端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="216"/>
+        <location filename="../src/common/utils.cpp" line="183"/>
+        <location filename="../src/common/utils.cpp" line="217"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>該終端中仍然有1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="186"/>
-        <location filename="../src/common/utils.cpp" line="220"/>
+        <location filename="../src/common/utils.cpp" line="187"/>
+        <location filename="../src/common/utils.cpp" line="221"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will kill all of them.</source>
         <translation>該終端中仍然有%1個進程在運行，關閉終端將殺死進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="191"/>
-        <location filename="../src/common/utils.cpp" line="211"/>
+        <location filename="../src/common/utils.cpp" line="192"/>
+        <location filename="../src/common/utils.cpp" line="212"/>
         <source>Close this window?</source>
         <translation>關閉這個窗口？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="192"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
+        <location filename="../src/common/utils.cpp" line="193"/>
+        <location filename="../src/common/utils.cpp" line="213"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>窗口內一些終端仍然有進程在運行，關閉窗口會殺死所有進程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Programs are still running in terminal</source>
         <translation>多個程式仍在執行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="229"/>
+        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Are you sure you want to uninstall it?</source>
         <translation>您確定要卸載它嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="242"/>
-        <location filename="../src/common/utils.cpp" line="246"/>
+        <location filename="../src/common/utils.cpp" line="243"/>
+        <location filename="../src/common/utils.cpp" line="247"/>
         <source>Are you sure you want to uninstall this application?</source>
         <translation>您確定要卸載終端嗎？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="243"/>
-        <location filename="../src/common/utils.cpp" line="247"/>
+        <location filename="../src/common/utils.cpp" line="244"/>
+        <location filename="../src/common/utils.cpp" line="248"/>
         <source>You will not be able to use Terminal any longer.</source>
         <translation>卸載後將無法再使用該應用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="253"/>
-        <location filename="../src/common/utils.cpp" line="297"/>
+        <location filename="../src/common/utils.cpp" line="254"/>
+        <location filename="../src/common/utils.cpp" line="298"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="331"/>
+        <location filename="../src/common/utils.cpp" line="332"/>
         <source>Set the work directory</source>
         <translation>設定終端機的啟動目錄</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="334"/>
+        <location filename="../src/common/utils.cpp" line="335"/>
         <source>Set the window mode on starting</source>
         <translation>設置終端開啟的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="337"/>
+        <location filename="../src/common/utils.cpp" line="338"/>
         <source>Execute a command in the terminal</source>
         <translation>於終端機執行程式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="340"/>
+        <location filename="../src/common/utils.cpp" line="341"/>
         <source>Run script string in the terminal</source>
         <translation>在終端中允許腳本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="343"/>
+        <location filename="../src/common/utils.cpp" line="344"/>
         <source>Run in quake mode</source>
         <translation>以雷神模式執行終端機</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="346"/>
+        <location filename="../src/common/utils.cpp" line="347"/>
         <source>Keep terminal open when command finishes</source>
         <translation>設置終端顯示命令或腳本執行後的結果</translation>
     </message>
@@ -970,27 +972,32 @@
         <translation>分組：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="192"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
+        <source>No Group</source>
+        <translation>無分組</translation>
+    </message>
+    <message>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="193"/>
         <source>Path:</source>
         <translation>位置：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="198"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="199"/>
         <source>Command:</source>
         <translation>命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="204"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="205"/>
         <source>Encoding:</source>
         <translation>編碼：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="210"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
         <source>Backspace key:</source>
         <translation>退格鍵：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="216"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
         <source>Delete key:</source>
         <translation>刪除鍵：</translation>
     </message>
@@ -999,55 +1006,55 @@
         <translation type="vanished">刪除伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="222"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="224"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="227"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
         <source>Edit Server</source>
         <translation>編輯伺服器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
         <source>Save</source>
         <comment>button</comment>
         <translation>儲 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="423"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="424"/>
         <source>Please enter a server name</source>
         <translation>請輸入伺服器名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="436"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="437"/>
         <source>Please enter an IP address</source>
         <translation>請輸入IP位址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="441"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="442"/>
         <source>Please enter a port</source>
         <translation>請輸入埠</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="447"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="448"/>
         <source>Please enter a username</source>
         <translation>請輸入使用者名稱</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="461"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
         <source>The server name already exists,</source>
         <translation>該伺服器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="462"/>
+        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="463"/>
         <source>please input another one. </source>
         <translation>請重新輸入</translation>
     </message>
@@ -1064,32 +1071,32 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Normal window</source>
         <translation>正常視窗</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Split screen</source>
         <translation>分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Maximum</source>
         <translation>最⼤化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="128"/>
+        <location filename="../src/settings/settings.cpp" line="131"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="718"/>
+        <location filename="../src/settings/settings.cpp" line="721"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="723"/>
+        <location filename="../src/settings/settings.cpp" line="726"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1169,90 +1176,90 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="474"/>
+        <location filename="../src/views/termwidget.cpp" line="477"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="477"/>
+        <location filename="../src/views/termwidget.cpp" line="480"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="486"/>
+        <location filename="../src/views/termwidget.cpp" line="489"/>
         <source>Open</source>
         <translation>開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
+        <location filename="../src/views/termwidget.cpp" line="493"/>
         <source>Open in file manager</source>
         <translation>在檔案管理器中開啟</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="502"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Horizontal split</source>
         <translation>水平分割</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="502"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="505"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>Vertical split</source>
         <translation>垂直分割</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="512"/>
-        <location filename="../src/views/termwidget.cpp" line="558"/>
+        <location filename="../src/views/termwidget.cpp" line="515"/>
+        <location filename="../src/views/termwidget.cpp" line="561"/>
         <source>New tab</source>
         <translation>建立標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="519"/>
+        <location filename="../src/views/termwidget.cpp" line="522"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="521"/>
+        <location filename="../src/views/termwidget.cpp" line="524"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="524"/>
+        <location filename="../src/views/termwidget.cpp" line="527"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="528"/>
+        <location filename="../src/views/termwidget.cpp" line="531"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="538"/>
+        <location filename="../src/views/termwidget.cpp" line="541"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="540"/>
+        <location filename="../src/views/termwidget.cpp" line="543"/>
         <source>Custom commands</source>
         <translation>自訂命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="542"/>
+        <location filename="../src/views/termwidget.cpp" line="545"/>
         <source>Remote management</source>
         <translation>遠端管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="546"/>
+        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>Upload file</source>
         <translation>上傳檔案</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="550"/>
         <source>Download file</source>
         <translation>下載檔案</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="552"/>
+        <location filename="../src/views/termwidget.cpp" line="555"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -1260,21 +1267,21 @@
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="197"/>
-        <location filename="../src/common/utils.cpp" line="231"/>
+        <location filename="../src/common/utils.cpp" line="198"/>
+        <location filename="../src/common/utils.cpp" line="232"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="199"/>
+        <location filename="../src/common/utils.cpp" line="200"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>離 開</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="232"/>
-        <location filename="../src/common/utils.cpp" line="264"/>
+        <location filename="../src/common/utils.cpp" line="233"/>
+        <location filename="../src/common/utils.cpp" line="265"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>


### PR DESCRIPTION
Bug: https://github.com/linuxdeepin/developer-center/issues/5149
Log: 给编辑服务器对话框中‘分组’为空值时添加提示语