### PR TITLE
chore: Bump version to 6.0.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-terminal (6.0.7) unstable; urgency=medium
+
+  * Fix compilation errors on deepin V23.
+    Add tips for empty group section in add server dialog.
+
+ -- Yutao Meng <mengyutao@deepin.org>  Mon, 28 Aug 2023 15:03:01 +0800
+
 deepin-terminal (6.0.6) unstable; urgency=medium
 
   * Feature:


### PR DESCRIPTION
includes PRs https://github.com/linuxdeepin/deepin-terminal/pull/291 and https://github.com/linuxdeepin/deepin-terminal/pull/292. 
Log: Bump version to 6.0.7