### PR TITLE
feat: 在光标所在屏幕唤起雷神窗口

### DIFF
--- a/src/main/windowsmanager.cpp
+++ b/src/main/windowsmanager.cpp
@@ -10,6 +10,7 @@
 #include "define.h"
 
 #include <QDebug>
+#include <QScreen>
 
 WindowsManager *WindowsManager::pManager = new WindowsManager();
 WindowsManager *WindowsManager::instance()
@@ -30,6 +31,9 @@ void WindowsManager::runQuakeWindow(TermProperties properties)
         m_quakeWindow->activateWindow();
         return;
     }
+    // 雷神窗口移动到光标所在的屏幕
+    QPoint cursorPoint = QCursor::pos();
+    m_quakeWindow->move(QGuiApplication::screenAt(cursorPoint)->geometry().topLeft());
     // Alt+F2的显隐功能实现点
     quakeWindowShowOrHide();
 }


### PR DESCRIPTION
之前雷神窗口只能够在主屏唤起。当前提交使得雷神窗口可以在任意光标所在的屏幕上被唤起。

Issue: https://github.com/linuxdeepin/developer-center/issues/5455
Log: 在光标所在屏幕唤起雷神窗口