### PR TITLE
fix: use QElapsedTimer instead of QTime

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -20,7 +20,7 @@
 #include <QDebug>
 #include <QCommandLineParser>
 #include <QTranslator>
-#include <QTime>
+#include <QElapsedTimer>
 
 DWIDGET_USE_NAMESPACE
 
@@ -29,7 +29,7 @@ DCORE_USE_NAMESPACE
 int main(int argc, char *argv[])
 {
     // 应用计时
-    QTime useTime;
+    QElapsedTimer useTime;
     useTime.start();
     //为了更精准，起动就度量时间
     qint64 startTime = QDateTime::currentDateTime().toMSecsSinceEpoch();


### PR DESCRIPTION
Fixes the following warning:

```
/build/deepin-terminal/src/deepin-terminal-6.0.6/src/main/main.cpp:33:18: warning: ‘void QTime::start()’ is deprecated: Use QElapsedTimer instead [-Wdeprecated-declarations]
   33 |     useTime.start();
```