### PR TITLE
chore: Bump version to 5.9.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-terminal (5.9.44) unstable; urgency=medium
+
+  * fix: Add 2 character width charset.
+  * feat: Improve debug log and add log category. 
+  * feat: [UI] Adapt compact mode.(Task: 292067)(Influence: UI)
+
+ -- renbin <renbin@uniontech.com>  Mon, 16 Oct 2023 15:54:30 +0800
+
 deepin-terminal (5.9.43) unstable; urgency=medium
 
   * New version 5.9.43.


### PR DESCRIPTION
Bump version to 5.9.44
PR:
* https://github.com/linuxdeepin/deepin-terminal/pull/284
* https://github.com/linuxdeepin/deepin-terminal/pull/301
* https://github.com/linuxdeepin/deepin-terminal/pull/302
* https://github.com/linuxdeepin/deepin-terminal/pull/303
* https://github.com/linuxdeepin/deepin-terminal/pull/304
* https://github.com/linuxdeepin/deepin-terminal/pull/305
* https://github.com/linuxdeepin/deepin-terminal/pull/306

Log: Bump version to 5.9.44