### PR TITLE
fix: Tab height error under low version dtk.

### DIFF
--- a/src/views/tabbar.cpp
+++ b/src/views/tabbar.cpp
@@ -191,6 +191,8 @@ TabBar::TabBar(QWidget *parent) : DTabBar(parent), m_rightClickTab(-1)
     QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this](){
         setTabHeight(DSizeModeHelper::element(COMMONHEIGHT_COMPACT, COMMONHEIGHT));
     });
+#else
+    setTabHeight(36);
 #endif
 }
 


### PR DESCRIPTION
适配紧凑模式引入问题.
修复在低版本DTK下编译的终端标签栏高度不固定问题.

Log: 修复低版本DTK下终端标签栏高度错误.