### PR TITLE
fix: Bug#5930 将主题设置为跟随系统后，再将鼠标移动到深色时，预览图的标题栏没有同步展示为深色

### DIFF
--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -309,10 +309,15 @@ inline void TermWidget::onColorThemeChanged(const QString &colorTheme)
 
 inline void TermWidget::onThemeChanged(DGuiApplicationHelper::ColorType themeType)
 {
+    Q_UNUSED(themeType);
     if ("System Theme" == Settings::instance()->colorScheme()) {
-        if (DApplicationHelper::instance()->themeType() != themeType) {
-            setTheme("System Theme");
+        QString theme;
+        if (DApplicationHelper::DarkType == DApplicationHelper::instance()->themeType()) {
+            theme = "Dark";
+        } else {
+            theme = "Light";
         }
+        setColorScheme(theme);
     }
 }
 
@@ -707,7 +712,6 @@ void TermWidget::changeTitleColor(int lightness)
 
 void TermWidget::setTheme(const QString &colorTheme)
 {
-    qInfo() << "dzw ==== " << colorTheme;
     QString theme = colorTheme;
     // 跟随系统
     if ("System Theme" == colorTheme) {

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -310,7 +310,9 @@ inline void TermWidget::onColorThemeChanged(const QString &colorTheme)
 inline void TermWidget::onThemeChanged(DGuiApplicationHelper::ColorType themeType)
 {
     if ("System Theme" == Settings::instance()->colorScheme()) {
-        setTheme("System Theme");
+        if (DApplicationHelper::instance()->themeType() != themeType) {
+            setTheme("System Theme");
+        }
     }
 }
 
@@ -696,24 +698,6 @@ void TermWidget::inputRemotePassword(const QString &remotePassword)
 
 void TermWidget::changeTitleColor(int lightness)
 {
-    QString colorTheme = Settings::instance()->colorScheme();
-    // 自定义主题
-    if (colorTheme == Settings::instance()->m_configCustomThemePath) {
-        DGuiApplicationHelper::ColorType systemTheme = DGuiApplicationHelper::DarkType;
-        if ("Light" == Settings::instance()->themeSetting->value("CustomTheme/TitleStyle")) {
-            systemTheme = DGuiApplicationHelper::LightType;
-        }
-        DApplicationHelper::instance()->setPaletteType(systemTheme);
-        return;
-    }
-
-    // 跟随系统
-    if ("System Theme" == colorTheme) {
-        DApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::UnknownType);
-        return;
-    }
-
-    // 其他
     if (lightness >= 192) {
         DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::LightType);
     } else {
@@ -723,14 +707,29 @@ void TermWidget::changeTitleColor(int lightness)
 
 void TermWidget::setTheme(const QString &colorTheme)
 {
+    qInfo() << "dzw ==== " << colorTheme;
     QString theme = colorTheme;
     // 跟随系统
     if ("System Theme" == colorTheme) {
+        DApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::UnknownType);
         if (DApplicationHelper::DarkType == DApplicationHelper::instance()->themeType()) {
             theme = "Dark";
         } else {
             theme = "Light";
         }
+        setColorScheme(theme);
+        return;
+    }
+
+    // 自定义主题
+    if (colorTheme == Settings::instance()->m_configCustomThemePath) {
+        DGuiApplicationHelper::ColorType systemTheme = DGuiApplicationHelper::DarkType;
+        if ("Light" == Settings::instance()->themeSetting->value("CustomTheme/TitleStyle")) {
+            systemTheme = DGuiApplicationHelper::LightType;
+        }
+        DApplicationHelper::instance()->setPaletteType(systemTheme);
+        setColorScheme(theme);
+        return;
     }
 
     // 设置主题


### PR DESCRIPTION
修复悬浮预览主题，会受选中的主题影响

Log: 将主题设置为跟随系统后，再将鼠标移动到深色时，预览图的标题栏没有同步展示为深色

Bug: https://github.com/linuxdeepin/developer-center/issues/5930