### PR TITLE
fix: Roll back gb18030 midification

### DIFF
--- a/3rdparty/terminalwidget/lib/Emulation.h
+++ b/3rdparty/terminalwidget/lib/Emulation.h
@@ -515,6 +515,14 @@ protected:
     /*const */KeyboardTranslator *_keyTranslator; // the keyboard layout
     /********************* Modify by ut000610 daizhengwen End ************************/
 
+    /**
+       @brief 检测当前iconv使用的GB18030编码是否为2005标准，2005标准强制使用上层补丁版本
+            通过检测2005和2022编码转的差异，以附录D中的编码为例验证
+            2005标准 0xFE51 --> \u20087
+            2022标准 0xFE51 --> \uE816
+       @return iconv使用GB18030编码是否为2005标准，默认返回true
+     */
+    bool detectIconvUse2005Standard();
 protected slots:
     /**
      * Schedules an update of attached views.


### PR DESCRIPTION
Description: iconv底层适配GB18030-2022标准,回退上层应用GB18030修改。当处于2005标准时 仍会强制使用上层修改补丁以适配2022标准。

Log: Roll back gb18030 midification