### PR TITLE
chore: Bump version to 5.9.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-terminal (5.9.47) unstable; urgency=medium
+
+  * fix: Fixed the issue of high CPU usage due to cursor flickering. 
+    (#317) (Bug: 231445)
+  * Revert "fix: Supplementary 2 character width character set (#284)". 
+    (#321) (Bug: 272385)
+
+ -- renbin <renbin@uniontech.com>  Mon, 25 Dec 2023 15:54:39 +0800
+
 deepin-terminal (5.9.46) unstable; urgency=medium
 
   * fix: Roll back gb18030 midification.


### PR DESCRIPTION
Bump version to 5.9.47
PR:
* https://github.com/linuxdeepin/deepin-terminal/pull/317
* https://github.com/linuxdeepin/deepin-terminal/pull/321

Log: Bump version to 5.9.47