### PR TITLE
fix: 修复雷神窗口无法设置模糊的问题

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2586,7 +2586,7 @@ void QuakeWindow::topToBottomAnimation()
         return;
 
     isNotAnimation = false;
-    this->setMinimumHeight(0);//设置最小高度为0,让动画效果流畅
+    this->setMinimumHeight(2); // 避免窗管强制取消模糊。
     currentPage()->setMinimumHeight(currentPage()->height());//设置page的最小高度，让动画效果时，page上信息不因为外框的变小而变小
 
     //动画代码
@@ -2594,7 +2594,7 @@ void QuakeWindow::topToBottomAnimation()
     m_heightAni->setEasingCurve(QEasingCurve::Linear);
     int durationTime = getQuakeAnimationTime();
     m_heightAni->setDuration(durationTime);
-    m_heightAni->setStartValue(1);
+    m_heightAni->setStartValue(2);
     m_heightAni->setEndValue(getQuakeHeight());
     m_heightAni->start(QAbstractAnimation::DeleteWhenStopped);
 


### PR DESCRIPTION
窗管在窗口很小的时候会强制禁用设置模糊。调大最小高度解决。

Issue: https://github.com/linuxdeepin/developer-center/issues/6568
Log: 修复雷神窗口无法设置模糊的问题