### PR TITLE
fix: Crash when show/close setting dialog.

### DIFF
--- a/src/main/service.h
+++ b/src/main/service.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -90,12 +89,10 @@ public:
     }
 
     /**
-     * @brief 重置设置框的所有者
+     * @brief 重置设置框的所有者，setParent(nullptr)
+     * @warning 父控件(终端窗口)关闭销毁前必须调用
      */
-    inline void resetSettingOwner()
-    {
-        m_settingOwner = nullptr;
-    }
+    void resetSettingOwner();
 
     /**
      * @brief i从term数量的角度判断是否允许继续创建


### PR DESCRIPTION
设置弹窗在构建时设置了父控件,而父控件(终端窗口)销毁
时同时销毁设置弹窗.导致关闭后在其它终端窗口打开设置
弹窗时,访问已销毁的弹窗对象,程序崩溃.
调整设置弹窗生命周期由 Service 维护,不过仍需要设置
父窗口以实现正常的显示坐标计算.

Log: 修复在多个窗口上切换显示设置弹窗崩溃的问题.
Bug: https://pms.uniontech.com/bug-view-28636.html
Influence: SettingDialog