### PR TITLE
fix: 修改日志调试模式适配配置文件

### DIFF
--- a/src/assets/config/debugconfig/org.deepin.terminal.json
+++ b/src/assets/config/debugconfig/org.deepin.terminal.json
@@ -4,7 +4,7 @@
   "submodules": [
     {
       "name": "deepin-terminal",
-      "exec": "/usr/share/deepin-debug-config/shell/deepin-terminal_debug.sh"
+      "exec": "deepin-terminal_debug.sh"
     }
   ],
   "reboot": 0,


### PR DESCRIPTION
Description: 修改日志调试模式适配配置文件，将脚本的绝对路径修改成相对路径

Log: 修改日志调试模式适配配置文件

Bug: https://pms.uniontech.com/bug-view-239503.html