### PR TITLE
fix: 无法打开未以'/'结尾的带端口号的链接

### DIFF
--- a/3rdparty/terminalwidget/lib/Filter.cpp
+++ b/3rdparty/terminalwidget/lib/Filter.cpp
@@ -515,13 +515,7 @@ void UrlFilter::HotSpot::activate(const QString &actionName)
 //regexp matches:
 // full url:
 // protocolname:// or www. followed by anything other than whitespaces, <, >, ' or ", and ends before whitespaces, <, >, ', ", ], !, comma and dot
-/** modify begin by ut001121 zhangmeng 20201215 for 1040-4 Ctrl键+鼠标点击超链接打开网页 */
-/** del
-const QRegExp UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]"));*/
-const QRegExp UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[\\w-.@]+"
-                                                     "([:]((6553[0-5])|[655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[0-9])[^0-9])?"
-                                                     "([/][\\w\\-\\@?^=%&/~\\+#.]+)?"));
-/** modify end by ut001121 */
+const QRegExp UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]"));
 
 // email address:
 // [word chars, dots or dashes]@[word chars, dots or dashes].[word chars]


### PR DESCRIPTION
优化的正则表达式在这种情况下，会把回车匹配进去，导致无法打开链接。
改用上游原来的正则解决。

Issue: https://github.com/linuxdeepin/developer-center/issues/6888
Log: 无法打开未以'/'结尾的带端口号的链接