### PR TITLE
feat: 改用DDesktopService的方法打开文件或文件夹

### DIFF
--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -423,25 +423,25 @@ inline void TermWidget::onOpenFileInFileManager()
 {
     //DDesktopServices::showFolder(QUrl::fromLocalFile(workingDirectory()));
 
-    //打开文件夹的方式 和  打开文件夹 并勾选文件的方式 如下
-    //dde-file-manager -n /data/home/lx777/my-wjj/git/2020-08/18-zoudu/build-deepin-terminal-unknown-Debug
-    //dde-file-manager --show-item a.pdf
-
     QProcess process;
     //未选择内容
     if (selectedText().isEmpty()) {
-        process.startDetached("dde-file-manager", {"-n", workingDirectory()});
+        DDesktopServices::showFolder(QUrl::fromLocalFile(workingDirectory()));
         return;
     }
 
     QFileInfo fi(workingDirectory() + "/" + selectedText());
     //选择的内容是文件或者文件夹
-    if (fi.isFile() || fi.isDir()) {
-        process.startDetached("dde-file-manager", {"--show-item", workingDirectory() + "/" + selectedText()});
+    if (fi.isDir()) {
+        DDesktopServices::showFolder(QUrl::fromLocalFile(fi.filePath()));
+        return;
+    } else if (fi.isFile()) {
+        DDesktopServices::showFileItem(QUrl::fromLocalFile(fi.filePath()));
         return;
     }
+
     //选择的文本不是文件也不是文件夹
-    process.startDetached("dde-file-manager", {"-n", workingDirectory()});
+    DDesktopServices::showFolder(QUrl::fromLocalFile(workingDirectory()));
 }
 
 /*** 修复 bug 28162 鼠标左右键一起按终端会退出 ***/


### PR DESCRIPTION
为避免第一次启动文管时共用终端的appid

Log: 改用DDesktopService的方法打开文件或文件夹