### PR TITLE
fix: the quake window overlaps with the dock

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2470,7 +2470,7 @@ void QuakeWindow::initWindowAttribute()
     resize(QSize(saveWidth, saveHeight));
     // 记录雷神高度
     m_quakeWindowHeight = saveHeight;
-    move(0, 0);
+    move(QApplication::primaryScreen()->availableGeometry().x(), QApplication::primaryScreen()->availableGeometry().y());
     /************************ Add by m000743 sunchengxi 2020-04-27:雷神窗口任务栏移动后位置异常问题 End  ************************/
 
     /******** Add by nt001000 renfeixiang 2020-05-20:增加setQuakeWindowMinHeight函数，设置雷神最小高度 Begin***************/

--- a/src/main/windowsmanager.cpp
+++ b/src/main/windowsmanager.cpp
@@ -21,18 +21,8 @@ WindowsManager *WindowsManager::instance()
 void WindowsManager::runQuakeWindow(TermProperties properties)
 {
     if (nullptr == m_quakeWindow) {
-        QPoint cursorPoint = QCursor::pos();
-        const QScreen *cursorScreen = QGuiApplication::screenAt(cursorPoint);
         qInfo() << "runQuakeWindow :create";
         m_quakeWindow = new QuakeWindow(properties);
-        m_quakeWindow->move(cursorScreen->geometry().topLeft());
-        //Add by ut001000 renfeixiang 2020-11-16 设置开始雷神动画效果标志
-        m_quakeWindow->setAnimationFlag(false);
-        m_quakeWindow->show();
-        //Add by ut001000 renfeixiang 2020-11-16 开始从上到下的动画
-        m_quakeWindow->topToBottomAnimation();
-        m_quakeWindow->activateWindow();
-        return;
     }
     // Alt+F2的显隐功能实现点
     quakeWindowShowOrHide();


### PR DESCRIPTION
初始化时，将窗口移动到 avaliableGeomotry 的顶点

Issues: linuxdeepin/developer-center#6557