### PR TITLE
feat: load keyboard layouts from runtime dir first

### DIFF
--- a/3rdparty/terminalwidget/CMakeLists.txt
+++ b/3rdparty/terminalwidget/CMakeLists.txt
@@ -155,6 +155,12 @@ set(HDRS_DISTRIB
     lib/TerminalDisplay.h
 )
 
+option(RUNDIR_KEYBOARD_LAYOUT_FIRST "Load keyboard layouts from application runtime directory" OFF)
+message(STATUS "Use runtime directory keyboard layouts first: ${RUNDIR_KEYBOARD_LAYOUT_FIRST}")
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(RUNDIR_KEYBOARD_LAYOUT_FIRST ON) # enable runtime layouts loading for debug
+endif()
+
 # dirs
 set(KB_LAYOUT_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${TERMINALWIDGET_LIBRARY_NAME}/kb-layouts")
 message(STATUS "Keyboard layouts will be installed in: ${KB_LAYOUT_DIR}")
@@ -250,6 +256,7 @@ target_compile_definitions(${TERMINALWIDGET_LIBRARY_NAME}
         "TRANSLATIONS_DIR=\"${TRANSLATIONS_DIR}\""
         "HAVE_POSIX_OPENPT"
         "HAVE_SYS_TIME_H"
+        $<$<BOOL:RUNDIR_KEYBOARD_LAYOUT_FIRST>:RUNDIR_KEYBOARD_LAYOUT_FIRST>
 )
 
 
@@ -297,6 +304,11 @@ install(DIRECTORY
     COMPONENT Runtime
     FILES_MATCHING PATTERN "*.keytab"
 )
+
+if(RUNDIR_KEYBOARD_LAYOUT_FIRST)
+    file(COPY lib/kb-layouts/ DESTINATION ${CMAKE_BINARY_DIR}/kb-layouts)
+endif()
+
 # color schemes
 install(DIRECTORY
     lib/color-schemes/

--- a/3rdparty/terminalwidget/lib/tools.cpp
+++ b/3rdparty/terminalwidget/lib/tools.cpp
@@ -22,41 +22,32 @@
 #include <QDir>
 #include <QtDebug>
 #include <QToolButton>
+#include <QLoggingCategory>
 
 
 /*! Helper function to get possible location of layout files.
 By default the KB_LAYOUT_DIR is used (linux/BSD/macports).
 But in some cases (apple bundle) there can be more locations).
 */
+Q_LOGGING_CATEGORY(qLcTools, "terminalwidget.tools", QtInfoMsg)
 QString get_kb_layout_dir()
 {
-//    qDebug() << __FILE__ << __FUNCTION__;
-
-    QString rval = QString();
-    QString k(QLatin1String(KB_LAYOUT_DIR));
-    QDir d(k);
-
-    //qDebug() << "default KB_LAYOUT_DIR: " << k;
-
-    if (d.exists())
-    {
-        rval = k.append(QLatin1Char('/'));
-        return rval;
+    QDir d(QCoreApplication::applicationDirPath());
+    QString ret;
+#if defined(RUNDIR_KEYBOARD_LAYOUT_FIRST) || defined(Q_OS_MAC)
+    if (d.exists("kb-layouts")) {
+        ret = d.absoluteFilePath("kb-layouts");
+    } else if (d.exists("../Resources/kb-layouts")) {
+        ret = d.absoluteFilePath("../Resources/kb-layouts");
     }
-
-#ifdef Q_OS_MAC
-    // subdir in the app location
-    d.setPath(QCoreApplication::applicationDirPath() + QLatin1String("/kb-layouts/"));
-    //qDebug() << d.path();
-    if (d.exists())
-        return QCoreApplication::applicationDirPath() + QLatin1String("/kb-layouts/");
-
-    d.setPath(QCoreApplication::applicationDirPath() + QLatin1String("/../Resources/kb-layouts/"));
-    if (d.exists())
-        return QCoreApplication::applicationDirPath() + QLatin1String("/../Resources/kb-layouts/");
+#else
+    d.setPath(QLatin1String(KB_LAYOUT_DIR));
+    if (d.exists()) {
+        ret = d.absolutePath();
+    }
 #endif
-    //qDebug() << "Cannot find KB_LAYOUT_DIR. Default:" << k;
-    return QString();
+    qCInfo(qLcTools) << "Found keyboard layout directory:" << ret;
+    return ret.append(QDir::separator());
 }
 
 /*! Helper function to add custom location of color schemes.


### PR DESCRIPTION
On MacOS or in debugging, we might need to load keyboard layouts from runtime directory first.

Log: load keyboard layouts from runtime dir first