### PR TITLE
fix: Bug# 点击自定义主题后未确认，菜单勾选状态错误

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2078,6 +2078,7 @@ void MainWindow::addThemeMenuItems()
 
         connect(switchThemeMenu, SIGNAL(mainWindowCheckThemeItemSignal()), this, SLOT(themeRecovery()));
         connect(switchThemeMenu, SIGNAL(menuHideSetThemeSignal()), this, SLOT(themeRecovery()));
+        connect(switchThemeMenu, &SwitchThemeMenu::aboutToShow, this, &MainWindow::checkThemeItem);
     }
 }
 


### PR DESCRIPTION
由于自定弹窗结果返回是异步的，所以修改为:
每次菜单点开重新进行勾选

Log: 点击自定义主题后未确认，菜单勾选状态错误