### PR TITLE
chore: [tag] new tag v6.15.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-terminal (6.5.0) unstable; urgency=medium
+
+  * New version 6.5.0.
+
+-- re2zero <yangwu@uniontech.com>  Mon, 20 Jan 2025 15:30:43 +0800
+
 deepin-terminal (5.9.51) unstable; urgency=medium
 
   * New version 5.9.51.


### PR DESCRIPTION
v6.15.0 release after Qt6 support.

Log: v6.15.0 release.