### PR TITLE
fix: [wayland] Window size exceeds the screen after setting the zoom.

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2635,7 +2635,12 @@ void NormalWindow::initWindowAttribute()
             saveWidth = WINDOW_DEFAULT_WIDTH;
             saveHeight = WINDOW_DEFAULT_HEIGHT;
         }
-        resize(QSize(saveWidth, saveHeight));
+        auto screen = qApp->primaryScreen();
+        int w = qMin(saveWidth, screen->geometry().width());
+        int h = qMin(saveHeight, screen->geometry().height());
+        if (w != saveWidth || h != saveHeight)
+            qCInfo(mainprocess) << QString("terminal`s size dose not matched screen, actual size: (%1, %2)").arg(w, h);
+        resize(QSize(w, h));
         singleFlagMove();
     }
 }


### PR DESCRIPTION
窗口大小超过屏幕时，x11下会自动最大化，wayland因协议设计，不会自动最大化，导致大小超出屏幕。 做规避，当窗口大小超过屏幕时，设置为屏幕大小。

Log: 修复bug

Bug: https://pms.uniontech.com/bug-view-305171.html