### PR TITLE
fix: fix build error in V25-Server

### DIFF
--- a/src/views/customthemesettingdialog.cpp
+++ b/src/views/customthemesettingdialog.cpp
@@ -15,6 +15,7 @@
 #include <DPushButton>
 #include <DSuggestButton>
 #include <DFontSizeManager>
+#include <DGuiApplicationHelper>
 #include <DPaletteHelper>
 #include <DVerticalLine>
 


### PR DESCRIPTION
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In member function 'virtual void ColorPushButton::paintEvent(QPaintEvent*)': /root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:81:9: error: 'DGuiApplicationHelper' has not been declared
   81 |     if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType())
      |         ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:81:45: error: 'DGuiApplicationHelper' has not been declared
   81 |     if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType())
      |                                             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In constructor 'CustomThemeSettingDialog::CustomThemeSettingDialog(QWidget*)':
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:169:13: error: 'DGuiApplicationHelper' has not been declared
  169 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, &CustomThemeSettingDialog::updateSizeMode);
      |             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:169:49: error: 'DGuiApplicationHelper' has not been declared
  169 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, &CustomThemeSettingDialog::updateSizeMode);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:170:13: error: 'DGuiApplicationHelper' has not been declared
  170 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::fontChanged, this, [this](){
      |             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:170:49: error: 'DGuiApplicationHelper' has not been declared
  170 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::fontChanged, this, [this](){
      |                                                 ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In member function 'void CustomThemeSettingDialog::initUITitle()':
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:214:9: error: 'DGuiApplicationHelper' has not been declared
  214 |     if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType())
      |         ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:214:44: error: 'DGuiApplicationHelper' has not been declared
  214 |     if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType())
      |                                            ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In member function 'void CustomThemeSettingDialog::initTitleConnections()':
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:401:13: error: 'DGuiApplicationHelper' has not been declared
  401 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, m_titleText, [ = ](DGuiApplicationHelper::ColorType themeType) {
      |             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:401:49: error: 'DGuiApplicationHelper' has not been declared
  401 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, m_titleText, [ = ](DGuiApplicationHelper::ColorType themeType) {
      |                                                 ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:401:109: error: 'DGuiApplicationHelper' has not been declared
  401 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, m_titleText, [ = ](DGuiApplicationHelper::ColorType themeType) {
      |                                                                                                             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:401:142: error: expected ',' or '...' before 'themeType'
  401 |     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, m_titleText, [ = ](DGuiApplicationHelper::ColorType themeType) {
      |                                                                                                                                              ^~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In lambda function:
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:404:13: error: 'DGuiApplicationHelper' has not been declared
  404 |         if (DGuiApplicationHelper::DarkType == themeType)
      |             ^~~~~~~~~~~~~~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:404:48: error: 'themeType' was not declared in this scope
  404 |         if (DGuiApplicationHelper::DarkType == themeType)
      |                                                ^~~~~~~~~
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp: In member function 'void CustomThemeSettingDialog::updateSizeMode()':
/root/rpmbuild/BUILD/deepin-terminal-6.5.2/src/views/customthemesettingdialog.cpp:538:9: error: 'DGuiApplicationHelper' has not been declared
  538 |     if (DGuiApplicationHelper::isCompactMode()) {
      |         ^~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/deepin-terminal.dir/build.make:751: CMakeFiles/deepin-terminal.dir/src/views/customthemesettingdialog.cpp.o] Error 1
make[2]: Leaving directory '/root/rpmbuild/BUILD/deepin-terminal-6.5.2/build'
make[2]: *** Waiting for unfinished jobs....
make[2]: Entering directory '/root/rpmbuild/BUILD/deepin-terminal-6.5.2/build'