### PR TITLE
chore: Update CMakeLists.txt to prioritize lxqt2-build-tools

### DIFF
--- a/3rdparty/terminalwidget/CMakeLists.txt
+++ b/3rdparty/terminalwidget/CMakeLists.txt
@@ -51,7 +51,12 @@ endif(DEFINED QT_DESIRED_VERSION)
 
 find_package(Qt${QT_DESIRED_VERSION} REQUIRED COMPONENTS Widgets)
 
-find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
+# 先尝试查找 lxqt2-build-tools，失败则查找 lxqt-build-tools
+find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} QUIET)
+if(NOT lxqt2-build-tools_FOUND)
+    find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
+endif()
+
 find_package(ICU COMPONENTS i18n uc REQUIRED)
 
 if(USE_UTF8PROC)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-terminal (6.5.12) unstable; urgency=medium
+
+  * chore: Update version to 6.5.11
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 08 Aug 2025 09:25:55 +0800
+
 deepin-terminal (6.5.11) unstable; urgency=medium
 
   * chore: Add new Lao translation file


### PR DESCRIPTION
- Modify CMakeLists.txt to first attempt to find lxqt2-build-tools, falling back to lxqt-build-tools if not found.

Log: Enhance build configuration for better tool detection.