### PR TITLE
chore: Add qt6-tools-dev to Build-Depends in debian/control

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-terminal (6.5.13) unstable; urgency=medium
+
+  * Add qt6-tools-dev to Build-Depends in debian/control
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 08 Aug 2025 12:45:47 +0800
+
 deepin-terminal (6.5.12) unstable; urgency=medium
 
   * chore: Update version to 6.5.11

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
  pkg-config,
  qt6-5compat-dev | hello,
  qt6-base-dev | qtbase5-dev,
+ qt6-tools-dev | qttools5-dev,
  qt6-tools-dev-tools | qttools5-dev-tools,
  qt6-base-private-dev | qtbase5-private-dev,
  libdtk6widget-dev | libdtkwidget-dev,


### PR DESCRIPTION
- Update debian/control to include qt6-tools-dev in Build-Depends for improved build support.

Log: Enhance build configuration by adding qt6-tools-dev dependency.