### PR TITLE
fix: Make the scrollbar follow changes in terminal transparency

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -686,6 +686,23 @@ void TerminalDisplay::setOpacity(qreal opacity)
     }*/
 
     _blendColor = color.rgba();
+
+    // Keep the scrollbar's appearance in sync with transparency settings
+    if (_scrollBar) {
+        const bool isTransparent = HAVE_TRANSPARENCY && qAlpha(_blendColor) < 0xff;
+
+        // Avoid style sheets and style hints: rely on palette and widget attributes
+        _scrollBar->setAutoFillBackground(!isTransparent);
+        _scrollBar->setAttribute(Qt::WA_TranslucentBackground, isTransparent);
+
+        QPalette pal = _scrollBar->palette();
+        QColor winColor = pal.color(QPalette::Window);
+        winColor.setAlpha(isTransparent ? 0 : 255);
+        pal.setColor(QPalette::Window, winColor);
+        _scrollBar->setPalette(pal);
+
+        _scrollBar->update();
+    }
 }
 
 void TerminalDisplay::setBackgroundImage(QString backgroundImage)


### PR DESCRIPTION
log: - When transparency is enabled in the terminal, the scrollbar background becomes transparent and auto
     - fill background is disabled to prevent opaque blocks from appearing.
     - When the terminal is opaque, the original style and background fill are restored to maintain consistency with the theme.

bug: https://pms.uniontech.com/bug-view-331175.html