### PR TITLE
fix: Abnormal scrollbar background when opaque

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -693,12 +693,15 @@ void TerminalDisplay::setOpacity(qreal opacity)
 
         // Avoid style sheets and style hints: rely on palette and widget attributes
         _scrollBar->setAutoFillBackground(!isTransparent);
-        _scrollBar->setAttribute(Qt::WA_TranslucentBackground, isTransparent);
-
+        
+        // Don't use WA_TranslucentBackground as it may affect positioning calculations
+        // Instead, only modify the palette for transparency
         QPalette pal = _scrollBar->palette();
-        QColor winColor = pal.color(QPalette::Window);
-        winColor.setAlpha(isTransparent ? 0 : 255);
-        pal.setColor(QPalette::Window, winColor);
+        
+        QColor bgColor = pal.color(QPalette::Window);
+        bgColor.setAlpha(isTransparent ? 0 : 255);
+        
+        pal.setColor(QPalette::Window, bgColor);
         _scrollBar->setPalette(pal);
 
         _scrollBar->update();


### PR DESCRIPTION
log: when adding scrollbars that changed transparency, the Qt::WA_TranslucentBackground property was set. This may have affected the scrollbar's style hints. When the scrollbar became transparent, the right-side positioning calculations could become inaccurate. Therefore, the Qt::WA_TranslucentBackground property setting was removed and replaced with more precise palette control.