### PR TITLE
fix: Abnormal display of the right-click menu on the taskbar

### DIFF
--- a/src/deepin-terminal.desktop
+++ b/src/deepin-terminal.desktop
@@ -319,8 +319,26 @@ Name[tr]=Quake Uçbirim
 Name[ug]=Quake تېرمىنالى
 Name[uk]=Термінал Quake
 Name[vi]=Quake Terminal
-Name[lo]=Quake ເທີມິນັນ
+Name[lo]=ຄວາກ ເທີມິນັນ
 Name[zh_CN]=雷神终端
 Name[zh_HK]=雷神終端
 Name[zh_TW]=雷神模式終端器
+
+
+# [Desktop Action] sections for compatibility with desktop environments expecting Desktop Actions
+[Desktop Action NewWindow]
+Exec=deepin-terminal
+Name=New Window
+Name[zh_CN]=新建窗口
+Name[zh_HK]=新建視窗
+Name[zh_TW]=新增視窗
+Name[lo]=ໜ້າຕ່າງໃໝ່
+
+[Desktop Action Quake]
+Exec=deepin-terminal --quake-mode
+Name=Quake Terminal
+Name[zh_CN]=雷神终端
+Name[zh_HK]=雷神終端
+Name[zh_TW]=雷神模式終端器
+Name[lo]=ຄວາກ ເທີມິນັນ
 


### PR DESCRIPTION
log: The actions in the .desktop file do not match the group names, and the standard [Desktop Action ...] section is missing, causing the Dock in certain environments to fail to display these two items. Therefore, rename the actions to NewWindow and Quake, and add the [Desktop Action NewWindow] and [Desktop Action Quake] sections.

bug: https://pms.uniontech.com/bug-view-331295.html