### PR TITLE
fix: Cursor Display Anomaly Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ message("   >>> Build with DTK: ${DTK_VERSION_MAJOR}")
 
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${qt_required_components})
 find_package(Dtk${DTK_VERSION_MAJOR} COMPONENTS Widget REQUIRED)
+if(Qt${QT_VERSION_MAJOR}_VERSION VERSION_GREATER_EQUAL 6.10)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS GuiPrivate WidgetsPrivate REQUIRED)
+endif()
 
 include(FindPkgConfig)
 


### PR DESCRIPTION
log: When the character is at the cursor position and within a hidden frame, first clear the cell using the cell background colour before proceeding with subsequent rendering. This ensures no outline from the previous frame remains. Extend the redraw area by 1 pixel on all sides to cover edge pixels, preventing border lines from falling outside the redraw region.