### PR TITLE
fix: fix crash on Arch when creating new tab & fix cmake compile error

### DIFF
--- a/3rdparty/terminalwidget/CMakeLists.txt
+++ b/3rdparty/terminalwidget/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 # CMP0000: Call the cmake_minimum_required() command at the beginning of the top-level
 # CMakeLists.txt file even before calling the project() command.
 # The cmake_minimum_required(VERSION) command implicitly invokes the cmake_policy(VERSION)

--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -3338,6 +3338,8 @@ QVariant TerminalDisplay::inputMethodQuery( Qt::InputMethodQuery query ) const
             {
                 // return the text from the current line
                 QString lineText;
+                if (_lineProperties.isEmpty())
+                    return lineText;
                 QTextStream stream(&lineText);
                 PlainTextDecoder decoder;
                 decoder.begin(&stream);


### PR DESCRIPTION
1. decoder.decodeLine(&_image[loc(0,cursorPos.y())],_usedColumns,_lineProperties[cursorPos.y()]); will raise an error when _lineProperties is empty. Check and early return in this case.

2. CMake Error at 3rdparty/terminalwidget/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max>
syntax
  to tell CMake that the project requires at least <min> but has been
updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

... so we have to increase cmake_minimum_required

After those fix deepin-terminal can be compiled and run on Archlinux without obvious bug.