### PR TITLE
fix: Tab Highlighting

### DIFF
--- a/src/views/tabbar.h
+++ b/src/views/tabbar.h
@@ -285,6 +285,13 @@ public slots:
 
 protected:
     /**
+     * @brief 绘制单个tab（用于在DTabBar内部绘制链路中修改文字颜色，避免paintEvent叠字）
+     * @note Qt5下原实现可通过TermTabStyle生效；Qt6下某些场景style不生效时，用此处兜底。
+     */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void paintTab(QPainter *painter, int index, const QStyleOptionTab &option) const override;
+#endif
+    /**
      * @brief 事件过滤器
      * @author ut000610 daizhengwen
      * @param watched


### PR DESCRIPTION
log: When the command launches in the foreground, `onTermIsIdle(bIdle=false)` identifies it as an active tab and directly removes the `NeedChangeTextColor` flag without setting the `needChange` indicator. After switching away, `onTermIsIdle(bIdle=true)` at command termination does not trigger color changes because the `needChange` flag remains unset.

bug: https://pms.uniontech.com/bug-view-337869.html