### PR TITLE
fix: Default focus is not on the input field

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -3119,6 +3119,17 @@ void NormalWindow::changeEvent(QEvent *event)
     QMainWindow::changeEvent(event);
 }
 
+void NormalWindow::showEvent(QShowEvent *event)
+{
+    // Let Qt finish its internal focus assignment first, then force focus back to terminal.
+    // This avoids the initial focus landing on TabBar/titlebar controls (TabFocus) which
+    // prevents typing immediately after opening a window.
+    DMainWindow::showEvent(event);
+    QTimer::singleShot(0, this, [this]() {
+        focusCurrentPage();
+    });
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 /**
  雷神终端窗口
@@ -3567,6 +3578,10 @@ void QuakeWindow::showEvent(QShowEvent *event)
     m_desktopMap[m_desktopIndex] = true;
 
     DMainWindow::showEvent(event);
+    // Ensure quake window is ready for typing immediately after it is shown.
+    QTimer::singleShot(0, this, [this]() {
+        focusCurrentPage();
+    });
 }
 
 bool QuakeWindow::event(QEvent *event)

--- a/src/main/mainwindow.h
+++ b/src/main/mainwindow.h
@@ -48,6 +48,7 @@ class TermProperties;
 class ShortcutManager;
 class MainWindowPluginInterface;
 class CustomCommandPlugin;
+class QShowEvent;
 
 
 /*******************************************************************************
@@ -942,6 +943,10 @@ public:
     virtual void updateMinHeight() override {return;}
 
 protected:
+    /**
+     * @brief 普通窗口显示事件：窗口首次显示时将焦点设置回终端输入区
+     */
+    void showEvent(QShowEvent *event) override;
     /**
      * @brief 普通终端窗口初始化标题栏
      * @author ut001121 zhangmeng

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -197,7 +197,10 @@ TermWidget::TermWidget(const TermProperties &properties, QWidget *parent) : QTer
         sendText(args);
     }
 
-    setFocusPolicy(Qt::NoFocus);
+    // Ensure terminal can receive keyboard focus immediately after a window/tab is shown.
+    // Otherwise MainWindow/TermWidgetPage setFocus() calls won't work and the initial focus
+    // may land on TabBar/titlebar controls, forcing users to click before typing.
+    setFocusPolicy(Qt::StrongFocus);
 
     TermWidgetPage *parentPage = qobject_cast<TermWidgetPage *>(parent);
     connect(this, &QTermWidget::uninstallTerminal, parentPage, &TermWidgetPage::uninstallTerminal);


### PR DESCRIPTION
log: TermWidget was set to Qt::NoFocus, causing external setFocus() to fail. This resulted in focus easily shifting to the TabFocus button in the TabBar/TitleBar. Therefore, focusPolicy was changed to Qt::StrongFocus.

bug: https://pms.uniontech.com/bug-view-347767.html