### PR TITLE
fix: the custom theme does not take effect.

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2148,12 +2148,21 @@ void MainWindow::addThemeMenuItems()
 
         //初始化时读取配置改变主题颜色
         QString  expandThemeStr = Settings::instance()->extendColorScheme();
+        qCInfo(mainprocess) << "expandThemeStr:" << expandThemeStr;
         if (!expandThemeStr.isEmpty()) {
-            if (THEME_NINE == expandThemeStr  || THEME_TEN == expandThemeStr) {
+            if (expandThemeStr.contains("customTheme.colorscheme")) { // 自定义主题
+                if (THEME_LIGHT == Settings::instance()->themeSetting->value("CustomTheme/TitleStyle").toString()) {
+                    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::LightType);
+                    emit DApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::LightType);
+                } else {
+                    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::DarkType);
+                    emit DApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::DarkType);
+                }
+            } else if (THEME_NINE == expandThemeStr || THEME_TEN == expandThemeStr) {
                 //选中了内置主题在9-10项之间 // 浅色方案系列
                 DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::LightType);
                 emit DApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::LightType);
-            }else{
+            } else {
                 DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::DarkType);
                 emit DApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::DarkType);
             }


### PR DESCRIPTION
When opening a new window, the custom theme does not take effect. Now, add the logic to read the custom theme configuration at the appropriate location to make the custom theme work. 
新建窗口时，自定义主题未生效。现在在合适位置添加读取自定义主题配置的逻辑，使得自定义主题生效。

Bug: https://pms.uniontech.com/bug-view-342849.html