### PR TITLE
fix: remove device pixel ratio scaling in drag pixmap

### DIFF
--- a/src/views/tabbar.cpp
+++ b/src/views/tabbar.cpp
@@ -546,8 +546,6 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
 {
     Q_UNUSED(option)
 
-    const qreal ratio = qApp->devicePixelRatio();
-
     QString termIdentifer = identifier(index);
     MainWindow *w = qobject_cast<MainWindow *>(this->window());
     if(!w)
@@ -557,12 +555,11 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
     int width = termPage->width();
     int height =  termPage->height();
     QImage screenshotImage(width, height, QImage::Format_ARGB32_Premultiplied);
-    screenshotImage.setDevicePixelRatio(ratio);
     termPage->render(&screenshotImage, QPoint(), QRegion(0, 0, width, height));
 
-    // 根据对应的ration缩放图像
-    int scaledWidth = static_cast<int>((width * ratio) / 5);
-    int scaledHeight = static_cast<int>((height * ratio) / 5);
+    // 缩放图像
+    int scaledWidth = width / 5;
+    int scaledHeight = height / 5;
     auto scaledImage = screenshotImage.scaled(scaledWidth, scaledHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
     const int shadowRadius = 10;
@@ -591,8 +588,8 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
         rectPath.addRect(0, 0, scaledWidth + shadowRadius, scaledHeight + shadowRadius);
         roundedRectPath.addRoundedRect(QRectF(0,
                                               0,
-                                              (scaledWidth / ratio) + shadowRadius,
-                                              (scaledHeight) / ratio + shadowRadius),
+                                              scaledWidth + shadowRadius,
+                                              scaledHeight + shadowRadius),
                                        cornerRadius,
                                        cornerRadius);
 


### PR DESCRIPTION
Removed device pixel ratio calculations from drag pixmap generation to
fix incorrect scaling on high DPI displays. The code was incorrectly
applying device pixel ratio multiple times which caused the drag preview
image to be too small. Simplified the image scaling by using direct
pixel dimensions without DPI scaling adjustments.

Log: Fixed drag tab preview display on high DPI screens

Influence:
1. Test dragging tabs on both standard and high DPI displays
2. Verify drag preview image size matches expected dimensions
3. Check that shadow effects render correctly around the preview
4. Test on different display scaling settings (100%, 150%, 200%)
5. Verify tab dragging functionality remains smooth

fix: 修复拖拽标签页预览在高DPI显示下的缩放问题

移除拖拽图像生成中的设备像素比计算，修复在高DPI显示器上预览图像过小的问
题。代码之前多次应用设备像素比导致缩放不正确。简化图像缩放逻辑，直接使用
像素尺寸而不进行DPI缩放调整。

Log: 修复高DPI屏幕上拖拽标签页预览显示问题

Influence:
1. 在标准和高DPI显示器上测试拖拽标签页功能
2. 验证拖拽预览图像尺寸是否符合预期
3. 检查预览图像周围的阴影效果是否正确渲染
4. 在不同显示缩放设置下测试（100%、150%、200%）
5. 验证标签页拖拽功能保持流畅

BUG: https://pms.uniontech.com/bug-view-342405.html
