### PR TITLE
fix: swap previous/next tab shortcuts to correct order

### DIFF
--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -151,13 +151,13 @@
                             "key": "previous_tab",
                             "name": "Previous tab",
                             "type": "shortcut",
-                            "default":  "Ctrl+Tab"
+                            "default":  "Ctrl+Shift+Tab"
                         },
                         {
                             "key": "next_tab",
                             "name": "Next tab",
                             "type": "shortcut",
-                            "default":  "Ctrl+Shift+Tab"
+                            "default":  "Ctrl+Tab"
                         },
                         {
                             "key": "vertical_split",


### PR DESCRIPTION
Change previous_tab from Ctrl+Tab to Ctrl+Shift+Tab Change next_tab from Ctrl+Shift+Tab to Ctrl+Tab

调换切换前后标签页快捷键为正确顺序
与 master 分支 5807f35f 保持一致

Log: 调换切换前后标签页快捷键为正确顺序
Influence: Ctrl+Tab 切换到下一个标签页，Ctrl+Shift+Tab 切换到上一个标签页