### PR TITLE
fix: sync build warning fixes and treeland crash fix from master

### DIFF
--- a/src/customcommand/customcommandoptdlg.cpp
+++ b/src/customcommand/customcommandoptdlg.cpp
@@ -15,7 +15,7 @@
 #include <DKeySequenceEdit>
 #include <DCommandLinkButton>
 #include <DDialogCloseButton>
-#include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 #include <DGuiApplicationHelper>
 #include <DWidgetUtil>
 #include <DLog>

--- a/src/encodeplugin/encodelistview.cpp
+++ b/src/encodeplugin/encodelistview.cpp
@@ -12,6 +12,7 @@
 
 //dtk
 #include <DLog>
+#include <DPaletteHelper>
 
 //qt
 #include <QScrollBar>

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -3519,7 +3519,7 @@ void QuakeWindow::resizeByCurrentScreen(bool force)
         setFixedWidth(windowWidth);
         setMinimumHeight(60);
         setMaximumHeight(cursorScreen->geometry().height() * 2 / 3);
-        connect(cursorScreen, &QScreen::availableGeometryChanged, this, &QuakeWindow::slotWorkAreaResized);
+        connect(cursorScreen, &QScreen::availableGeometryChanged, this, &QuakeWindow::slotWorkAreaResized, Qt::UniqueConnection);
     }
 }
 

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -1187,13 +1187,14 @@ QString MainWindow::getConfigWindowState()
 QSize MainWindow::halfScreenSize()
 {
     qCDebug(mainprocess) << "Enter MainWindow::halfScreenSize";
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    auto desk = qApp->desktop()->availableGeometry();
-#else
-    auto desk = qApp->primaryScreen()->availableGeometry();
-#endif
-    int w = desk.width();
-    int h = desk.height();
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen) {
+        qCritical() << "Can't get the screen where the cursor is located!";
+        return QSize(0 ,0);
+    }
+
+    int w = screen->availableGeometry().width();
+    int h = screen->availableGeometry().height();
 
     QSize size;
     //开启窗管特效时会有1px的border
@@ -3230,20 +3231,10 @@ void QuakeWindow::initTitleBar()
 void QuakeWindow::slotWorkAreaResized()
 {
     qCInfo(mainprocess)  << "Workspace size change!";
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    auto desk = QApplication::desktop()->availableGeometry();
-#else
-    auto desk = QGuiApplication::primaryScreen()->availableGeometry();
-#endif
-
-    /******** Modify by nt001000 renfeixiang 2020-05-20:修改成只需要设置雷神窗口宽度,根据字体高度设置雷神最小高度 Begin***************/
-    setMinimumWidth(desk.width());
+    resizeByCurrentScreen(true);
     setWindowMinHeightForFont();
     /******** Add by ut001000 renfeixiang 2020-08-07:workAreaResized时改变大小，bug#41436***************/
     updateMinHeight();
-    /******** Modify by nt001000 renfeixiang 2020-05-20:修改成只需要设置雷神窗口宽度,根据字体高度设置雷神最小高度 End***************/
-    move(desk.x(), desk.y());
-    setFixedWidth(desk.width());
     return ;
 }
 
@@ -3252,13 +3243,6 @@ void QuakeWindow::initWindowAttribute()
     qCDebug(mainprocess) << "Enter QuakeWindow::initWindowAttribute";
     /************************ Add by m000743 sunchengxi 2020-04-27:雷神窗口任务栏移动后位置异常问题 Begin************************/
     setWindowRadius(0);
-    //QRect deskRect = QApplication::desktop()->availableGeometry();//获取可用桌面大小
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    QDesktopWidget *desktopWidget = QApplication::desktop();
-    QRect screenRect = desktopWidget->screenGeometry(); //获取设备屏幕大小
-#else
-    QRect screenRect = QGuiApplication::primaryScreen()->geometry();
-#endif
     Qt::WindowFlags windowFlags = this->windowFlags();
     setWindowFlags(windowFlags | Qt::WindowStaysOnTopHint/* | Qt::FramelessWindowHint | Qt::BypassWindowManagerHint*/ /*| Qt::Dialog*/);
     //wayland时需要隐藏WindowTitle
@@ -3269,35 +3253,9 @@ void QuakeWindow::initWindowAttribute()
     //add a line by ut001121 zhangmeng 2020-04-27雷神窗口禁用移动(修复bug#22975)
     setEnableSystemMove(false);//    setAttribute(Qt::WA_Disabled, true);
 
-    /******** Modify by m000714 daizhengwen 2020-03-26: 窗口高度超过２／３****************/
-    setMinimumSize(screenRect.size().width(), 60);
-    setMaximumHeight(screenRect.size().height() * 2 / 3);
-    /********************* Modify by m000714 daizhengwen End ************************/
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    // 计算屏幕宽度，设置雷神终端宽度
-    QList<QScreen *> screenList = qApp->screens();
-    int w = screenList[0]->geometry().width();
-    for (auto it = screenList.constBegin(); it != screenList.constEnd(); ++it) {
-        QRect rect = (*it)->geometry();
-        if (rect.x() == 0 && rect.y() == 0) {
-            w = rect.width();
-            break;
-        }
-    }
-    setFixedWidth(w);
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    connect(desktopWidget, &QDesktopWidget::workAreaResized, this, &QuakeWindow::slotWorkAreaResized);
-#else
-    connect(QGuiApplication::primaryScreen(), &QScreen::availableGeometryChanged, this, &QuakeWindow::slotWorkAreaResized);
-#endif
-
-    int saveHeight = getQuakeHeight();
-    int saveWidth = screenRect.size().width();
-    resize(QSize(saveWidth, saveHeight));
-    // 记录雷神高度
-    m_quakeWindowHeight = saveHeight;
-    move(0, 0);
-    /************************ Add by m000743 sunchengxi 2020-04-27:雷神窗口任务栏移动后位置异常问题 End  ************************/
+    resizeByCurrentScreen(true);
+    // FIXME(hualet): don't know why, just keep it for now.
+    getQuakeHeight();
 
     /******** Add by nt001000 renfeixiang 2020-05-20:增加setQuakeWindowMinHeight函数，设置雷神最小高度 Begin***************/
     setWindowMinHeightForFont();
@@ -3548,6 +3506,21 @@ void QuakeWindow::sendWindowForhibitMove(bool forhibit)
     int32_t ldata = forhibit;
     xcb_change_property(QX11Info::connection(), XCB_PROP_MODE_REPLACE, this->winId(),
                         reply, reply, 32, 1, &ldata);
+}
+
+void QuakeWindow::resizeByCurrentScreen(bool force)
+{
+    QPoint cursorPoint = QCursor::pos();
+    const QScreen *quakeScreen = QGuiApplication::screenAt(pos());
+    const QScreen *cursorScreen = QGuiApplication::screenAt(cursorPoint);
+    if (force || (!isVisible() && quakeScreen->serialNumber() != cursorScreen->serialNumber())) {
+        int windowWidth = cursorScreen->geometry().width();
+        move(cursorScreen->geometry().topLeft());
+        setFixedWidth(windowWidth);
+        setMinimumHeight(60);
+        setMaximumHeight(cursorScreen->geometry().height() * 2 / 3);
+        connect(cursorScreen, &QScreen::availableGeometryChanged, this, &QuakeWindow::slotWorkAreaResized);
+    }
 }
 
 void QuakeWindow::changeEvent(QEvent *event)

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -3513,7 +3513,7 @@ void QuakeWindow::resizeByCurrentScreen(bool force)
     QPoint cursorPoint = QCursor::pos();
     const QScreen *quakeScreen = QGuiApplication::screenAt(pos());
     const QScreen *cursorScreen = QGuiApplication::screenAt(cursorPoint);
-    if (force || (!isVisible() && quakeScreen->serialNumber() != cursorScreen->serialNumber())) {
+    if (cursorScreen && (force || (!isVisible() && quakeScreen && quakeScreen->serialNumber() != cursorScreen->serialNumber()))) {
         int windowWidth = cursorScreen->geometry().width();
         move(cursorScreen->geometry().topLeft());
         setFixedWidth(windowWidth);

--- a/src/main/mainwindow.h
+++ b/src/main/mainwindow.h
@@ -1201,6 +1201,8 @@ private:
      * @param forhibit
      */
     void sendWindowForhibitMove(bool forhibit);
+
+    void resizeByCurrentScreen(bool force);
 };
 
 #endif  // MAINWINDOW_H

--- a/src/main/windowsmanager.cpp
+++ b/src/main/windowsmanager.cpp
@@ -27,13 +27,6 @@ void WindowsManager::runQuakeWindow(TermProperties properties)
     if (nullptr == m_quakeWindow) {
         qCInfo(mainprocess)  << "Create QuakeWindow!";
         m_quakeWindow = new QuakeWindow(properties);
-        //Add by ut001000 renfeixiang 2020-11-16 设置开始雷神动画效果标志
-        m_quakeWindow->setAnimationFlag(false);
-        m_quakeWindow->show();
-        //Add by ut001000 renfeixiang 2020-11-16 开始从上到下的动画
-        m_quakeWindow->topToBottomAnimation();
-        m_quakeWindow->activateWindow();
-        return;
     }
     // Alt+F2的显隐功能实现点
     quakeWindowShowOrHide();
@@ -43,6 +36,17 @@ void WindowsManager::runQuakeWindow(TermProperties properties)
 void WindowsManager::quakeWindowShowOrHide()
 {
     qCDebug(mainprocess) << "Enter quakeWindowShowOrHide";
+    QPoint cursorPoint = QCursor::pos();
+    const QScreen *quakeScreen = QGuiApplication::screenAt(m_quakeWindow->pos());
+    const QScreen *cursorScreen = QGuiApplication::screenAt(cursorPoint);
+    if (!m_quakeWindow->isVisible() && quakeScreen != nullptr && cursorScreen != nullptr && quakeScreen->serialNumber() != cursorScreen->serialNumber()) {
+        int windowWidth = cursorScreen->geometry().width();
+        m_quakeWindow->move(cursorScreen->geometry().topLeft());
+        m_quakeWindow->setFixedWidth(windowWidth);
+        m_quakeWindow->setMinimumHeight(60);
+        m_quakeWindow->setMaximumHeight(cursorScreen->geometry().height() * 2 / 3);
+    }
+
     //隐藏 则 显示终端
     if (!m_quakeWindow->isVisible()) {
         qCDebug(mainprocess) << "Branch: QuakeWindow is not visible, showing it";

--- a/src/remotemanage/groupconfigoptdlg.cpp
+++ b/src/remotemanage/groupconfigoptdlg.cpp
@@ -24,6 +24,7 @@
 
 #include <DSuggestButton>
 #include <DVerticalLine>
+#include <DPaletteHelper>
 
 GroupConfigOptDlg::GroupConfigOptDlg(const QString &groupName, QWidget *parent)
     : DAbstractDialog(false, parent),
@@ -48,7 +49,7 @@ GroupConfigOptDlg::GroupConfigOptDlg(const QString &groupName, QWidget *parent)
     // 字色
     DPalette palette = m_titleLabel->palette();
     QColor color;
-    if (DApplicationHelper::DarkType == DApplicationHelper::instance()->themeType())
+    if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType())
         color = QColor::fromRgb(192, 198, 212, 255);
     else
         color = QColor::fromRgb(0, 26, 46, 255);

--- a/src/remotemanage/remotemanagementtoppanel.cpp
+++ b/src/remotemanage/remotemanagementtoppanel.cpp
@@ -250,7 +250,7 @@ void RemoteManagementTopPanel::showPrevPanel()
     // 动画效果 要显示的界面
     QPropertyAnimation *animation1 = nullptr;
     switch (prevType) {
-    case ServerConfigManager::PanelType_Manage:
+    case ServerConfigManager::PanelType_Manage: {
         qCDebug(remotemanage) << "showing manage panel";
         // 刷新主界面
         m_remoteManagementPanel->refreshPanel();
@@ -264,7 +264,8 @@ void RemoteManagementTopPanel::showPrevPanel()
         animation1 = new QPropertyAnimation(m_remoteManagementPanel, "geometry");
         connect(animation1, &QPropertyAnimation::finished, animation1, &QPropertyAnimation::deleteLater);
         break;
-    case ServerConfigManager::PanelType_Group:
+    }
+    case ServerConfigManager::PanelType_Group: {
         qCDebug(remotemanage) << "showing group panel";
         // 刷新分组列表
         m_serverConfigGroupPanel->refreshData(m_group);
@@ -274,6 +275,7 @@ void RemoteManagementTopPanel::showPrevPanel()
         animation1 = new QPropertyAnimation(m_serverConfigGroupPanel, "geometry");
         connect(animation1, &QPropertyAnimation::finished, animation1, &QPropertyAnimation::deleteLater);
         break;
+    }
     case ServerConfigManager::PanelType_Search: {
         qCDebug(remotemanage) << "showing search panel";
         // 刷新列表 => 搜索框能被返回，只能是全局搜索
@@ -292,8 +294,9 @@ void RemoteManagementTopPanel::showPrevPanel()
         // 动画效果的设置
         animation1 = new QPropertyAnimation(m_remoteManagementSearchPanel, "geometry");
         connect(animation1, &QPropertyAnimation::finished, animation1, &QPropertyAnimation::deleteLater);
-    }
     break;
+    }
+    case ServerConfigManager::PanelType_Serverlist: { break; }
     }
     if (nullptr == animation || nullptr == animation1) {
         qCWarning(remotemanage) << "do not has animation";
@@ -366,6 +369,9 @@ void RemoteManagementTopPanel::setPanelShowState(ServerConfigManager::PanelType 
     case ServerConfigManager::PanelType_Search:
         qCDebug(remotemanage) << "setting search panel show state";
         m_remoteManagementSearchPanel->m_isShow = true;
+        break;
+    case ServerConfigManager::PanelType_Serverlist:
+        qCDebug(remotemanage) << "setting server list panel show state";
         break;
     }
 }

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -285,7 +285,7 @@ void Settings::addShellOption()
     // 初始值
     keysList << DEFAULT_SHELL;
     // 数据转换
-    for (const QString key : shellsMap.keys()) {
+    for (const QString &key : shellsMap.keys()) {
         keysList << key;
     }
     g_shellConfigCombox->addItems(keysList);
@@ -432,7 +432,6 @@ int Settings::QuakeDuration() const
     const int step = settings->option("advanced.window.quake_window_animation_duration")->data("step").toInt();
     return settings->option("advanced.window.quake_window_animation_duration")->value().toInt() * step;
 }
-
 QString Settings::encoding() const
 {
     qCDebug(tsettings) << "Getting encoding:" << m_EncodeName;

--- a/src/views/itemwidget.cpp
+++ b/src/views/itemwidget.cpp
@@ -9,6 +9,7 @@
 #include "iconbutton.h"
 
 // dtk
+#include <DPaletteHelper>
 
 // qt
 #include <QDebug>
@@ -97,6 +98,9 @@ void ItemWidget::setFuncIcon(ItemFuncType iconType)
     case ItemFuncType_UngroupedItem:
         m_funcButton->hide();
         m_deleteButton->hide();
+        break;
+    default:
+        break;
     }
 
 }
@@ -122,7 +126,7 @@ void ItemWidget::setText(const QString &firstline, const QString &secondline)
         // 输入的第二行信息
         m_secondText = secondline;
         break;
-    case ItemFuncType_Group:
+    case ItemFuncType_Group: {
         qCDebug(views) << "Branch: ItemFuncType_Group";
         // 第二行 组内服务器个数
         int serverCount = ServerConfigManager::instance()->getServerCount(firstline);
@@ -131,6 +135,9 @@ void ItemWidget::setText(const QString &firstline, const QString &secondline)
             serverCount = 0;
         }
         m_secondText = QString("%1 server").arg(serverCount);
+        break;
+    }
+    default:
         break;
     }
     // 设置第二行信息

--- a/src/views/listview.cpp
+++ b/src/views/listview.cpp
@@ -776,6 +776,8 @@ void ListView::setItemIcon(ItemFuncType type, ItemWidget *item)
     case ItemFuncType_UngroupedItem:
         item->setIcon("dt_server");
         break;
+    default:
+        break;
     }
     qCDebug(views) << "ListView::setItemIcon finished";
 }
@@ -1023,6 +1025,8 @@ void ListView::deleteItem(const QString &key, ItemFuncType type)
         break;
     case ItemFuncType_Group:
         title = tr("Cancel Server Group");
+        break;
+    default:
         break;
     }
     QString alertText;


### PR DESCRIPTION
Sync changes from master branch commits #356 and #378:
- Add null check for QScreen in halfScreenSize() to prevent crash on treeland
- Refactor Quake window screen handling with new resizeByCurrentScreen()
- Fix build warnings: add DPaletteHelper includes, switch default branches
- Use DGuiApplicationHelper instead of deprecated DApplicationHelper

Log: 同步master分支构建警告修复和treeland崩溃修复
Influence: 修复Wayland环境下treeland崩溃问题，消除构建警告