### PR TITLE
fix: prevent window manager from disabling blur on Quake window

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -3383,7 +3383,7 @@ void QuakeWindow::topToBottomAnimation()
         return;
 
     isNotAnimation = false;
-    this->setMinimumHeight(0);//设置最小高度为0,让动画效果流畅
+    this->setMinimumHeight(2); // 避免窗管强制取消模糊。
     currentPage()->setMinimumHeight(currentPage()->height());//设置page的最小高度，让动画效果时，page上信息不因为外框的变小而变小
 
     //动画代码
@@ -3391,7 +3391,7 @@ void QuakeWindow::topToBottomAnimation()
     m_heightAni->setEasingCurve(QEasingCurve::Linear);
     int durationTime = getQuakeAnimationTime();
     m_heightAni->setDuration(durationTime);
-    m_heightAni->setStartValue(1);
+    m_heightAni->setStartValue(2);
     m_heightAni->setEndValue(getQuakeHeight());
     m_heightAni->start(QAbstractAnimation::DeleteWhenStopped);
 


### PR DESCRIPTION
Set minimumHeight to 2 instead of 0 to prevent the window manager from forcibly disabling the blur effect on the Quake terminal window. Sync from master commit #323.

Log: 修复雷神窗口无法设置模糊的问题
Influence: 保持雷神窗口的模糊效果