### PR TITLE
fix: flow control configuration inconsistency

### DIFF
--- a/3rdparty/terminalwidget/lib/Session.cpp
+++ b/3rdparty/terminalwidget/lib/Session.cpp
@@ -953,7 +953,7 @@ void Session::setFlowControlEnabled(bool enabled)
 }
 bool Session::flowControlEnabled() const
 {
-    return _flowControl;
+    return _shellProcess->flowControlEnabled();
 }
 //void Session::fireZModemDetected()
 //{

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -421,7 +421,7 @@
                             "default": "$SHELL"
                         },
                         {
-                            "key": "enable_ctrl_flow",
+                            "key": "disable_ctrl_flow",
                             "text": "Disable flow control using Ctrl+S, Ctrl+Q",
                             "type": "checkbox",
                             "default": "false"

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -1722,17 +1722,15 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
         }
         /********************* Modify by ut000610 daizhengwen End ************************/
         if ((Qt::ControlModifier == keyEvent->modifiers()) && (Qt::Key_S == keyEvent->key())) {
-            if (!Settings::instance()->enableControlFlow())
-                return true;
 
             assert(term);
-            if (term->isActiveWindow())
+            if (term->isActiveWindow() && term->flowControlEnabled())
                 term->showFlowMessage(true);
         }
 
         if ((Qt::ControlModifier == keyEvent->modifiers()) && (Qt::Key_Q == keyEvent->key())) {
             assert(term);
-            if (term->isActiveWindow())
+            if (term->isActiveWindow() && term->flowControlEnabled())
                 term->showFlowMessage(false);
         }
 

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -324,7 +324,7 @@ void Settings::initConnection()
     qCDebug(tsettings) << "Initializing connections";
     connect(settings, &Dtk::Core::DSettings::valueChanged, this, [ = ](const QString & key, const QVariant & value) {
         Q_UNUSED(value)
-        if (key.contains("basic.interface.") || key.contains("advanced.cursor.") || key.contains("advanced.scroll.")) {
+        if (key.contains("basic.interface.") || key.contains("advanced.cursor.") || key.contains("advanced.scroll.") || key.contains("advanced.shell.")) {
             qCDebug(tsettings) << "Terminal setting changed:" << key;
             emit terminalSettingChanged(key);
         } else if (key.contains("shortcuts.")) {
@@ -717,14 +717,6 @@ void Settings::handleWidthFont()
 bool Settings::disableControlFlow(void)
 {
     return settings->option("advanced.shell.disable_ctrl_flow")->value().toBool();
-}
-
-bool Settings::enableControlFlow(void)
-{
-    // qCDebug(tsettings) << "Getting control flow setting";
-    bool enable = !settings->option("advanced.shell.enable_ctrl_flow")->value().toBool();
-    // qCDebug(tsettings) << "Control flow enabled:" << enable;
-    return enable;
 }
 
 bool Settings::enableDebuginfod()

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -211,7 +211,6 @@ public:
      * @author 朱科伟
      * @return
      */
-    bool enableControlFlow(void);
     bool disableControlFlow(void);
     // 是否启用debuginfod：设置或取消DEBUGINFOD_URLS环境变量
     bool enableDebuginfod();

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -164,6 +164,9 @@ TermWidget::TermWidget(const TermProperties &properties, QWidget *parent) : QTer
     // 设置是否启用Ctrl+鼠标点击设置光标位置
     enableSetCursorPosition(Settings::instance()->enableSetCursorPosition());
 
+    // 流控制
+    setFlowControlEnabled(!Settings::instance()->disableControlFlow());
+
     // 按键滚动
     setPressingScroll(Settings::instance()->PressingScroll());
 


### PR DESCRIPTION
Sync from master branch #288.
- Change config key from enable_ctrl_flow to disable_ctrl_flow
- Remove enableControlFlow() function, use disableControlFlow() only
- Add advanced.shell. to settings signal connection
- Check term->flowControlEnabled() instead of settings value in mainwindow
- Add initial setFlowControlEnabled() call in TermWidget constructor
- Fix Session::flowControlEnabled() to return actual process state