### PR TITLE
feat: update window title based on current tab

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -252,6 +252,7 @@ inline void MainWindow::slotTabCurrentChanged(int index)
     }
 
     focusPage(newTabIdentifier);
+    updateWindowTitle();
 }
 
 inline void MainWindow::slotTabAddRequested()
@@ -1149,6 +1150,7 @@ void MainWindow::onTermTitleChanged(QString title)
         qCInfo(mainprocess) << "customName is false, setTabText";
         m_tabbar->setTabText(tabPage->identifier(), title);
     }
+    updateWindowTitle();
 
     // 判定第一次修改标题的时候，认为终端已经创建成功
     // 以此认为第一次打开终端窗口结束，记录时间
@@ -2902,6 +2904,11 @@ void MainWindow::themeActionHoveredSlot(QAction *action)
         Settings::instance()->bSwitchTheme = false;
         switchThemeAction(action);
     }
+}
+
+inline void MainWindow::updateWindowTitle()
+{
+    setWindowTitle(QString("%1 - %2").arg(m_tabbar->tabText(m_tabbar->currentIndex())).arg(QObject::tr("Terminal")));
 }
 
 void MainWindow::onCommandActionTriggered()

--- a/src/main/mainwindow.h
+++ b/src/main/mainwindow.h
@@ -804,6 +804,11 @@ protected:
      */
     void setTitlebarNoFocus(QWidget * titlebar);
 
+    /**
+     * @brief 根据当前标签页标题更新窗口名
+     */
+    inline void updateWindowTitle();
+
 protected:
     // 初始化标题栏
     virtual void initTitleBar() = 0;


### PR DESCRIPTION
Sync from master branch #285.
- Add updateWindowTitle() function to update window title with current tab text
- Call updateWindowTitle() when tab is changed
- Call updateWindowTitle() when term title is changed