### PR TITLE
feat: Add OSC52 clipboard support

### DIFF
--- a/3rdparty/terminalwidget/lib/Emulation.h
+++ b/3rdparty/terminalwidget/lib/Emulation.h
@@ -320,6 +320,23 @@ public slots:
     void receiveData(const char *buffer, int len, bool isCommandExec);
 
 signals:
+    /**
+     * @brief OSC52 clipboard operation request
+     *
+     * Emitted when a terminal program sends OSC52 escape sequence.
+     * Format: ESC ] 52 ; target ; base64-data BEL
+     *
+     * @param target Clipboard target:
+     *        - 'c' = CLIPBOARD (system clipboard, Ctrl+C/V)
+     *        - 'p' = PRIMARY (X11 primary selection, middle-click paste)
+     *        - 's' = SECONDARY (X11 secondary selection)
+     *        - '0' = All clipboards
+     * @param base64Data Base64-encoded clipboard data
+     *
+     * @author dzw1995
+     * @date 2026-03-14
+     */
+    void osc52ClipboardRequest(char target, const QString &base64Data);
 
     /**
      * Emitted when a buffer of data is ready to send to the

--- a/3rdparty/terminalwidget/lib/Session.cpp
+++ b/3rdparty/terminalwidget/lib/Session.cpp
@@ -118,6 +118,9 @@ Session::Session(QObject* parent) :
              SLOT(sendData(const char *,int,const QTextCodec *)) );
     connect( _emulation,SIGNAL(lockPtyRequest(bool)),_shellProcess,SLOT(lockPty(bool)) );
     connect( _emulation,SIGNAL(useUtf8Request(bool)),_shellProcess,SLOT(setUtf8Mode(bool)) );
+    // OSC52
+    connect(_emulation, SIGNAL(osc52ClipboardRequest(char,QString)),
+            this, SIGNAL(osc52ClipboardRequest(char,QString)));
 
     connect( _shellProcess,SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(done(int)) );
     // not in kprocess anymore connect( _shellProcess,SIGNAL(done(int)), this, SLOT(done(int)) );

--- a/3rdparty/terminalwidget/lib/Session.h
+++ b/3rdparty/terminalwidget/lib/Session.h
@@ -557,6 +557,9 @@ signals:
     // warning提示信息 currentShell当前使用的shell, 启用shell是否成功 true 替换了shell false 替换shell但启动失败
     void shellWarningMessage(QString currentShell, bool isSuccess);
 
+    // OSC52 clipboard operation request
+    void osc52ClipboardRequest(char target, const QString &base64Data);
+
 private slots:
     void done(int);
 

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -414,6 +414,41 @@ void Vt102Emulation::processWindowAttributeChange()
     return;
   }
 
+  // ========== OSC52 Special Handling ==========
+  if (attributeToChange == 52) {
+      // Extract Pt parameter (everything after semicolon)
+      // Format: "target;base64-data"
+      QString pt = QString::fromWCharArray(
+          tokenBuffer + i + 1,      // Skip semicolon
+          tokenBufferPos - i - 2    // Subtract BEL
+      );
+
+      // Split target and base64 data
+      int semiPos = pt.indexOf(';');
+      if (semiPos > 0) {
+          char target = pt[0].toLatin1();  // 'c', 'p', 's', or '0'
+          QString base64Data = pt.mid(semiPos + 1);
+
+          // Store to buffer
+          _pendingOSC52Data = base64Data;
+
+          // Emit signal directly - will be handled by TermWidget
+          emit osc52ClipboardRequest(target, base64Data);
+
+          // Clear buffer after consumption
+          _pendingOSC52Data.clear();
+
+          // OSC52 handling complete
+          return;
+      } else {
+          // Malformed: only target, no data (clear clipboard)
+          char target = pt[0].toLatin1();
+          emit osc52ClipboardRequest(target, QString());
+          return;
+      }
+  }
+  // ========== End OSC52 Handling ==========
+
   // copy from the first char after ';', and skipping the ending delimiter
   // 0x07 or 0x92. Note that as control characters in OSC text parts are
   // ignored, only the second char in ST ("\e\\") is appended to tokenBuffer.

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.h
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.h
@@ -195,6 +195,11 @@ private:
   QTimer* _titleUpdateTimer;
 
     bool _reportFocusEvents;
+
+    /**
+     * @brief Temporary buffer for OSC52 base64 data
+     */
+    QString _pendingOSC52Data;
 };
 
 }

--- a/3rdparty/terminalwidget/lib/qtermwidget.cpp
+++ b/3rdparty/terminalwidget/lib/qtermwidget.cpp
@@ -503,6 +503,10 @@ void QTermWidget::init(int startnow)
 
     //将终端活动状态传给SessionManager单例
     connect(this, SIGNAL(isTermIdle(bool)), SessionManager::instance(), SIGNAL(sessionIdle(bool)));
+
+    // Connect OSC52 signal from emulation
+    connect(m_impl->m_session, SIGNAL(osc52ClipboardRequest(char,QString)),
+            this, SIGNAL(osc52ClipboardRequest(char,QString)));
 }
 
 QTermWidget::~QTermWidget()

--- a/3rdparty/terminalwidget/lib/qtermwidget.h
+++ b/3rdparty/terminalwidget/lib/qtermwidget.h
@@ -346,6 +346,11 @@ signals:
     // 标签标题参数改变 dzw 2020-12-2
     void titleArgsChange(QString key, QString value);
 
+    /**
+     * @brief Forward OSC52 clipboard request from Emulation
+     */
+    void osc52ClipboardRequest(char target, const QString &base64Data);
+
 public slots:
     // Copy selection to clipboard
     void copyClipboard();

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -336,7 +336,13 @@
                             "text": "Copy on select",
                             "default": true
                         },
-			    {
+                        {
+                            "key": "allow_osc52",
+                            "type": "checkbox",
+                            "text": "Allow OSC52 clipboard access",
+                            "default": true
+                        },
+                        {
                             "key": "set_cursor_position",
                             "type": "checkbox",
                             "text": "Allow Ctrl + left mouse click to set cursor position",

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -549,6 +549,11 @@ bool Settings::IsPasteSelection()
     return settings->option("advanced.cursor.auto_copy_selection")->value().toBool();
 }
 
+bool Settings::allowOSC52() const
+{
+    return settings->option("advanced.cursor.allow_osc52")->value().toBool();
+}
+
 bool Settings::isShortcutConflict(const QString &Name, const QString &Key)
 {
     for (QString &tmpKey : settings->keys()) {

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -195,6 +195,13 @@ public:
     bool IsPasteSelection();
 
     /**
+     * @brief 获取当前配置粘贴是否为选择内容
+     * @author dzw1995
+     * @return
+     */
+    bool allowOSC52() const;
+
+    /**
      * @brief 与设置里的快捷键冲突检测
      * @author n014361 王培利
      * @param Name 快捷键名称

--- a/src/settings/settings_translation.cpp
+++ b/src/settings/settings_translation.cpp
@@ -152,4 +152,7 @@ void GenerateSettingTranslate()
     Q_UNUSED(set_cursor_position);
     auto enable_debuginfod = QObject::tr("The HTTP file server used for transmitting debugging information resources");
     Q_UNUSED(enable_debuginfod);
+    // OSC52 clipboard
+    auto advanced_cursor_allow_osc52Text = QObject::tr("Allow OSC52 clipboard access");
+    Q_UNUSED(advanced_cursor_allow_osc52Text);
 }

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -210,6 +210,10 @@ void TermWidget::initConnections()
     // 接收触控板事件
     connect(Service::instance(), &Service::touchPadEventSignal, this, &TermWidget::onTouchPadSignal);
     connect(Service::instance(), &Service::hostnameChanged, this, &TermWidget::onHostnameChanged);
+
+    // Connect OSC52 signal
+    connect(this, &QTermWidget::osc52ClipboardRequest,
+            this, &TermWidget::handleOSC52Clipboard);
 }
 
 inline void TermWidget::onSetTerminalFont()
@@ -1256,6 +1260,90 @@ void TermWidget::onShellMessage(QString currentShell, bool isSuccess)
 
         showShellMessage(strShellNoFound);
     }
+}
+
+void TermWidget::handleOSC52Clipboard(char target, const QString &base64Data)
+{
+    // ========== Security Check 1: User Settings ==========
+    if (!Settings::instance()->allowOSC52()) {
+        qWarning() << "OSC52: Blocked by user settings (allowOSC52=false)";
+        return;
+    }
+
+    // ========== Security Check 2: Data Size Limit ==========
+    const int MAX_CLIPBOARD_SIZE = 1024 * 1024;  // 1MB
+
+    if (base64Data.size() > MAX_CLIPBOARD_SIZE) {
+        qWarning().nospace() << "OSC52: Rejected - data too large ("
+                             << base64Data.size()
+                             << " bytes, max=" << MAX_CLIPBOARD_SIZE << ")";
+        return;
+    }
+
+    // ========== Base64 Decode ==========
+    QByteArray decoded;
+
+    if (base64Data.isEmpty()) {
+        // Empty data: clear clipboard
+        decoded = QByteArray();
+    } else {
+        // Normal Base64 decode
+        decoded = QByteArray::fromBase64(base64Data.toLatin1());
+
+        // Check decode failure
+        if (decoded.isEmpty() && !base64Data.isEmpty()) {
+            qWarning() << "OSC52: Base64 decoding failed for data:"
+                       << base64Data.left(50) << "...";
+            return;
+        }
+    }
+
+    // ========== UTF-8 Decode ==========
+    QString text = QString::fromUtf8(decoded);
+
+    if (text.isEmpty() && !decoded.isEmpty()) {
+        qWarning() << "OSC52: Invalid UTF-8 encoding in clipboard data";
+        return;
+    }
+
+    // ========== Write to System Clipboard ==========
+    QClipboard *clipboard = QApplication::clipboard();
+
+    qInfo().nospace() << "OSC52: Writing " << text.size()
+                      << " bytes to clipboard (target: " << target << ")";
+
+    switch (target) {
+        case 'p':
+            // PRIMARY selection (X11 middle-click paste)
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case 's':
+            // SECONDARY selection (X11, rarely used)
+            // Qt doesn't directly support SECONDARY, use Selection
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case '0':
+            // All clipboards
+            clipboard->setText(text, QClipboard::Clipboard);
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case 'c':
+        default:
+            // CLIPBOARD (system clipboard, Ctrl+C/V)
+            clipboard->setText(text, QClipboard::Clipboard);
+
+            // If "Copy on select" is enabled, also write to PRIMARY
+            // This allows middle-click paste for OSC52 content
+            if (Settings::instance()->IsPasteSelection()) {
+                clipboard->setText(text, QClipboard::Selection);
+            }
+            break;
+    }
+
+    qInfo() << "OSC52: Successfully copied to clipboard";
 }
 
 void TermWidget::wheelEvent(QWheelEvent *event)

--- a/src/views/termwidget.h
+++ b/src/views/termwidget.h
@@ -306,7 +306,15 @@ public slots:
      * @param isSuccess 启用shell是否成功 true 替换了shell false 替换shell但启动失败
      */
     void onShellMessage(QString currentShell, bool isSuccess);
-
+    /**
+     * @brief Handle OSC52 clipboard request
+     * @param target Clipboard target ('c', 'p', 's', '0')
+     * @param base64Data Base64-encoded data
+     *
+     * @author dzw1995
+     * @date 2026-03-14
+     */
+    void handleOSC52Clipboard(char target, const QString &base64Data);
 signals:
     void termRequestRenameTab(QString newTabName);
     void termIsIdle(QString tabIdentifier, bool bIdle);

--- a/translations/deepin-terminal.ts
+++ b/translations/deepin-terminal.ts
@@ -2,283 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
-    <name>CustomCommandOptDlg</name>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
-        <source>Name:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
-        <source>Command:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
-        <source>Shortcuts:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="213"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="219"/>
-        <source>Required</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="138"/>
-        <source>Add Command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="147"/>
-        <source>Edit Command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="157"/>
-        <source>Delete Command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
-        <source>Add</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="182"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="624"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="380"/>
-        <source>Please enter a name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="394"/>
-        <source>Please enter a command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="444"/>
-        <source>The name already exists,</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="445"/>
-        <source>please input another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CustomCommandPanel</name>
-    <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="196"/>
-        <source>Add Command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="200"/>
-        <source>No commands yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CustomCommandPlugin</name>
-    <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
-        <source>Custom commands</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CustomCommandSearchRstPanel</name>
-    <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="132"/>
-        <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CustomThemeSettingDialog</name>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
-        <source>Custom Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
-        <source>Style:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
-        <source>Fore color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
-        <source>Back color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
-        <source>Prompt PS1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
-        <source>Prompt PS2:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="424"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GroupConfigOptDlg</name>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="39"/>
-        <source>Group Name(Required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="41"/>
-        <source>Add Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="44"/>
-        <source>Edit Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
-        <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="65"/>
-        <source>Please enter a group name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="69"/>
-        <source>The name should be no more than 30 characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ListView</name>
-    <message>
-        <location filename="../src/views/listview.cpp" line="868"/>
-        <source>Delete Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="870"/>
-        <source>Delete Custom Command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="873"/>
-        <source>Cancel Server Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="882"/>
-        <source>Ungrouped servers will go back to server list!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="498"/>
-        <location filename="../src/views/listview.cpp" line="880"/>
-        <source>Are you sure you want to delete %1?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="224"/>
-        <location filename="../src/main/mainwindow.cpp" line="276"/>
-        <source>New window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="291"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="702"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="704"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1752"/>
-        <source>Type path to download file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="2049"/>
-        <source>Custom Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>QObject</name>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="17"/>
@@ -321,14 +44,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="145"/>
         <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Blur background</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/service.cpp" line="214"/>
-        <source>debuginfod URLs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -347,7 +64,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="176"/>
         <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
@@ -388,15 +104,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1594"/>
         <location filename="../src/settings/settings_translation.cpp" line="57"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1592"/>
-        <location filename="../src/main/mainwindow.cpp" line="2183"/>
-        <location filename="../src/main/terminalapplication.cpp" line="25"/>
         <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Terminal</source>
         <translation type="unfinished"></translation>
@@ -407,61 +119,51 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="63"/>
         <source>Custom commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="65"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="67"/>
         <source>Remote management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="101"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="103"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="105"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="107"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="109"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="111"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="113"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
@@ -472,55 +174,46 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="125"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="127"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="129"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="131"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="133"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="135"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="137"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="139"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
@@ -556,33 +249,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
+        <location filename="../src/settings/settings_translation.cpp" line="156"/>
+        <source>Allow OSC52 clipboard access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/views/tabbar.cpp" line="486"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="208"/>
         <source>Rename title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="71"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="73"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="75"/>
         <source>Default size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
@@ -593,7 +284,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
@@ -609,13 +299,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="87"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
@@ -626,30 +314,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
         <source>Close other workspaces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="1247"/>
-        <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="1253"/>
-        <source>Could not open &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="1255"/>
-        <source>Could not find &quot;%1&quot;, unable to run it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="1298"/>
-        <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -658,644 +324,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="97"/>
-        <location filename="../src/views/termwidget.cpp" line="496"/>
         <source>Close workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="99"/>
         <source>Horizontal split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="115"/>
         <source>Vertical split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="263"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="627"/>
-        <location filename="../src/main/service.cpp" line="416"/>
-        <source>please set another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/terminalapplication.cpp" line="28"/>
-        <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1590"/>
-        <source>Tabs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
-        <location filename="../src/views/tabbar.cpp" line="480"/>
-        <source>Close tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
-        <source>Select tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1610"/>
-        <source>Switch focus to &quot;+&quot; icon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="157"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
-        <source>Select file to upload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="162"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
-        <source>Upload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="230"/>
-        <source>Programs are still running in terminal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="216"/>
-        <source>Close this terminal?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="217"/>
-        <source>There is still a process running in this terminal. Closing the terminal will terminate it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="221"/>
-        <source>There are still %1 processes running in this terminal. Closing the terminal will terminate all of them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="192"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
-        <source>Close this window?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="193"/>
-        <location filename="../src/common/utils.cpp" line="213"/>
-        <source>There are still processes running in this window. Closing the window will terminate all of them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="136"/>
-        <location filename="../src/main/mainwindow.cpp" line="1768"/>
-        <source>Select a directory to save the file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="230"/>
-        <source>Are you sure you want to uninstall it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="243"/>
-        <location filename="../src/common/utils.cpp" line="247"/>
-        <source>Are you sure you want to uninstall this application?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="244"/>
-        <location filename="../src/common/utils.cpp" line="248"/>
-        <source>You will not be able to use Terminal any longer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="253"/>
-        <location filename="../src/views/listview.cpp" line="499"/>
-        <location filename="../src/views/listview.cpp" line="893"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="254"/>
-        <location filename="../src/common/utils.cpp" line="298"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
-        <source>Execute a command in the terminal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="341"/>
-        <source>Run script string in the terminal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
-        <source>Set the work directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
-        <source>Set the window mode on starting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="344"/>
-        <source>Run in quake mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="347"/>
-        <source>Keep terminal open when command finishes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="387"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="476"/>
-        <source>The name should be no more than 32 characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="142"/>
-        <location filename="../src/main/mainwindow.cpp" line="1774"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="546"/>
-        <source>Select</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="542"/>
-        <source>Select the private key file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>Remote tab title format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
-        <location filename="../src/views/tabbar.cpp" line="483"/>
-        <source>Close other tabs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="894"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/listview.cpp" line="500"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="245"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>RemoteManagementPanel</name>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="210"/>
-        <source>Add Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="211"/>
-        <source>Add Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="215"/>
-        <source>No servers yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>RemoteManagementPlugin</name>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
-        <source>Remote management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
-        <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>RemoteManagementSearchPanel</name>
-    <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="211"/>
-        <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ServerConfigManager</name>
-    <message>
-        <location filename="../src/remotemanage/serverconfigmanager.cpp" line="87"/>
-        <source>Groups</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigmanager.cpp" line="88"/>
-        <source>Servers</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ServerConfigOptDlg</name>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="91"/>
-        <source>Add Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="127"/>
-        <source>Server name:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
-        <source>Required</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="137"/>
-        <source>Address:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
-        <source>Port:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="165"/>
-        <source>Username:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="172"/>
-        <source>Password:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="178"/>
-        <source>Certificate:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
-        <source>Group:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
-        <source>No Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="193"/>
-        <source>Path:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="199"/>
-        <source>Command:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="205"/>
-        <source>Encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
-        <source>Backspace key:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
-        <source>Delete key:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="224"/>
-        <source>Add</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
-        <source>Edit Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="470"/>
-        <source>Please enter a server name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="483"/>
-        <source>Please enter an IP address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="488"/>
-        <source>Please enter a port</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="494"/>
-        <source>Please enter a username</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
-        <source>The server name already exists,</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
-        <source>please input another one. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Service</name>
-    <message>
-        <location filename="../src/main/service.cpp" line="412"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Settings</name>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
-        <source>Split screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
-        <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
-        <source>Normal window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
-        <source>Maximum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="722"/>
-        <source>Fast</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/settings.cpp" line="726"/>
-        <source>Slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ShortcutManager</name>
-    <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
-        <source>The shortcut %1 is invalid, </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
-        <source>The shortcut %1 was already in use, </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TabRenameWidget</name>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="42"/>
-        <source>Insert</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="88"/>
-        <source>username: %u</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
-        <source>username@: %U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
-        <source>remote host: %h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="75"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="87"/>
-        <source>session number: %#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="75"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="89"/>
-        <source>title set by shell: %w</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="86"/>
-        <source>program name: %n</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="86"/>
-        <source>current directory (short): %d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="87"/>
-        <source>current directory (long): %D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="88"/>
-        <source>local host: %h</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TermWidget</name>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="469"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="472"/>
-        <source>Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="481"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="485"/>
-        <source>Open in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
-        <source>Horizontal split</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="492"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
-        <source>Vertical split</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="503"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
-        <source>New tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="510"/>
-        <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="512"/>
-        <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="515"/>
-        <source>Find</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="519"/>
-        <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="529"/>
-        <source>Encoding</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
-        <source>Custom commands</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
-        <source>Remote management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
-        <source>Upload file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="538"/>
-        <source>Download file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/views/termwidget.cpp" line="1200"/>
-        <source>The debuginfod settings will be effective after restart</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Utils</name>
-    <message>
-        <location filename="../src/common/utils.cpp" line="198"/>
-        <location filename="../src/common/utils.cpp" line="232"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="200"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/utils.cpp" line="233"/>
-        <location filename="../src/common/utils.cpp" line="265"/>
-        <source>OK</source>
-        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-terminal_zh_CN.ts
+++ b/translations/deepin-terminal_zh_CN.ts
@@ -1,279 +1,228 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CustomCommandOptDlg</name>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="97"/>
         <source>Name:</source>
-        <translation>名称：</translation>
+        <translation type="vanished">名称：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="99"/>
         <source>Command:</source>
-        <translation>命令：</translation>
+        <translation type="vanished">命令：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="101"/>
         <source>Shortcuts:</source>
-        <translation>快捷键：</translation>
+        <translation type="vanished">快捷键：</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="112"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="113"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="213"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="219"/>
         <source>Required</source>
-        <translation>必填</translation>
+        <translation type="vanished">必填</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="138"/>
         <source>Add Command</source>
-        <translation>添加命令</translation>
+        <translation type="vanished">添加命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="147"/>
         <source>Edit Command</source>
-        <translation>编辑命令</translation>
+        <translation type="vanished">编辑命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="157"/>
         <source>Delete Command</source>
-        <translation>删除命令</translation>
+        <translation type="vanished">删除命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="178"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="180"/>
         <source>Add</source>
         <comment>button</comment>
-        <translation>添 加</translation>
+        <translation type="vanished">添 加</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="182"/>
         <source>Save</source>
         <comment>button</comment>
-        <translation>保 存</translation>
+        <translation type="vanished">保 存</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="624"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="380"/>
         <source>Please enter a name</source>
-        <translation>请输入名称</translation>
+        <translation type="vanished">请输入名称</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="394"/>
         <source>Please enter a command</source>
-        <translation>请输入命令</translation>
+        <translation type="vanished">请输入命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="444"/>
         <source>The name already exists,</source>
-        <translation>该名称已存在，</translation>
+        <translation type="vanished">该名称已存在，</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="445"/>
         <source>please input another one.</source>
-        <translation>请重新输入</translation>
+        <translation type="vanished">请重新输入</translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="196"/>
         <source>Add Command</source>
-        <translation>添加命令</translation>
+        <translation type="vanished">添加命令</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandpanel.cpp" line="200"/>
         <source>No commands yet</source>
-        <translation>未添加自定义命令</translation>
+        <translation type="vanished">未添加自定义命令</translation>
     </message>
 </context>
 <context>
     <name>CustomCommandPlugin</name>
     <message>
-        <location filename="../src/customcommand/customcommandplugin.cpp" line="35"/>
         <source>Custom commands</source>
-        <translation>自定义命令</translation>
+        <translation type="vanished">自定义命令</translation>
     </message>
 </context>
 <context>
     <name>CustomCommandSearchRstPanel</name>
     <message>
-        <location filename="../src/customcommand/customcommandsearchrstpanel.cpp" line="132"/>
         <source>Search</source>
-        <translation>搜索</translation>
+        <translation type="vanished">搜索</translation>
     </message>
 </context>
 <context>
     <name>CustomThemeSettingDialog</name>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="238"/>
         <source>Custom Theme</source>
-        <translation>自定义主题</translation>
+        <translation type="vanished">自定义主题</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="262"/>
         <source>Style:</source>
-        <translation>主题风格：</translation>
+        <translation type="vanished">主题风格：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="266"/>
         <source>Light</source>
-        <translation>浅色</translation>
+        <translation type="vanished">浅色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="271"/>
         <source>Dark</source>
-        <translation>深色</translation>
+        <translation type="vanished">深色</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="325"/>
         <source>Fore color:</source>
-        <translation>前景色：</translation>
+        <translation type="vanished">前景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="332"/>
         <source>Back color:</source>
-        <translation>背景色：</translation>
+        <translation type="vanished">背景色：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="350"/>
         <source>Prompt PS1:</source>
-        <translation>提示符PS1：</translation>
+        <translation type="vanished">提示符PS1：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="354"/>
         <source>Prompt PS2:</source>
-        <translation>提示符PS2：</translation>
+        <translation type="vanished">提示符PS2：</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="424"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/views/customthemesettingdialog.cpp" line="431"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
 </context>
 <context>
     <name>GroupConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="39"/>
         <source>Group Name(Required)</source>
-        <translation>分组名称（必填）</translation>
+        <translation type="vanished">分组名称（必填）</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="41"/>
         <source>Add Group</source>
-        <translation>添加分组</translation>
+        <translation type="vanished">添加分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="44"/>
         <source>Edit Group</source>
-        <translation>编辑分组</translation>
+        <translation type="vanished">编辑分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
         <source>Cancel</source>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Add</source>
-        <translation>添 加</translation>
+        <translation type="vanished">添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Save</source>
-        <translation>保 存</translation>
+        <translation type="vanished">保 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="65"/>
         <source>Please enter a group name</source>
-        <translation>请输入服务器组名称</translation>
+        <translation type="vanished">请输入服务器组名称</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="69"/>
         <source>The name should be no more than 30 characters</source>
-        <translation>名称长度不得超过30个字符</translation>
+        <translation type="vanished">名称长度不得超过30个字符</translation>
     </message>
 </context>
 <context>
     <name>ListView</name>
     <message>
-        <location filename="../src/views/listview.cpp" line="868"/>
         <source>Delete Server</source>
-        <translation>删除服务器</translation>
+        <translation type="vanished">删除服务器</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="870"/>
         <source>Delete Custom Command</source>
-        <translation>删除自定义命令</translation>
+        <translation type="vanished">删除自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="873"/>
         <source>Cancel Server Group</source>
-        <translation>取消服务器组</translation>
+        <translation type="vanished">取消服务器组</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="882"/>
         <source>Ungrouped servers will go back to server list!</source>
-        <translation>取消分组后服务器将还原至服务器列表！</translation>
+        <translation type="vanished">取消分组后服务器将还原至服务器列表！</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="498"/>
-        <location filename="../src/views/listview.cpp" line="880"/>
         <source>Are you sure you want to delete %1?</source>
-        <translation>您确定要删除 %1 吗？</translation>
+        <translation type="vanished">您确定要删除 %1 吗？</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="224"/>
-        <location filename="../src/main/mainwindow.cpp" line="276"/>
         <source>New window</source>
-        <translation>新建窗口</translation>
+        <translation type="vanished">新建窗口</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="291"/>
         <source>Settings</source>
-        <translation>设置</translation>
+        <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="702"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="704"/>
         <source>Close</source>
         <comment>button</comment>
-        <translation>关 闭</translation>
+        <translation type="vanished">关 闭</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1752"/>
         <source>Type path to download file</source>
-        <translation>请输入下载文件的路径</translation>
+        <translation type="vanished">请输入下载文件的路径</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2049"/>
         <source>Custom Theme</source>
-        <translation>自定义主题</translation>
+        <translation type="vanished">自定义主题</translation>
     </message>
 </context>
 <context>
@@ -319,15 +268,13 @@
         <translation>雷神窗口动画速度</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="145"/>
         <location filename="../src/settings/settings_translation.cpp" line="33"/>
         <source>Blur background</source>
         <translation>背景模糊</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="214"/>
         <source>debuginfod URLs</source>
-        <translation>debuginfod URLs</translation>
+        <translation type="vanished">debuginfod URLs</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="35"/>
@@ -345,7 +292,6 @@
         <translation>字体大小</translation>
     </message>
     <message>
-        <location filename="../src/main/service.cpp" line="176"/>
         <location filename="../src/settings/settings_translation.cpp" line="41"/>
         <source>Opacity</source>
         <translation>透明度</translation>
@@ -386,15 +332,11 @@
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1594"/>
         <location filename="../src/settings/settings_translation.cpp" line="57"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1592"/>
-        <location filename="../src/main/mainwindow.cpp" line="2183"/>
-        <location filename="../src/main/terminalapplication.cpp" line="25"/>
         <location filename="../src/settings/settings_translation.cpp" line="59"/>
         <source>Terminal</source>
         <translation>终端</translation>
@@ -405,61 +347,51 @@
         <translation>工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="63"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="65"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="67"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="101"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="103"/>
         <source>Next tab</source>
         <translation>下一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
         <location filename="../src/settings/settings_translation.cpp" line="105"/>
         <source>Previous tab</source>
         <translation>上一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="107"/>
         <source>Select left workspace</source>
         <translation>选择左边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="109"/>
         <source>Select lower workspace</source>
         <translation>选择下面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="111"/>
         <source>Select right workspace</source>
         <translation>选择右边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="113"/>
         <source>Select upper workspace</source>
         <translation>选择上面的工作区</translation>
@@ -470,55 +402,46 @@
         <translation>标签标题</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="125"/>
         <source>Go to tab 1</source>
         <translation>切换到标签 1</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="127"/>
         <source>Go to tab 2</source>
         <translation>切换到标签 2</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1641"/>
         <location filename="../src/settings/settings_translation.cpp" line="129"/>
         <source>Go to tab 3</source>
         <translation>切换到标签 3</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="131"/>
         <source>Go to tab 4</source>
         <translation>切换到标签 4</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="133"/>
         <source>Go to tab 5</source>
         <translation>切换到标签 5</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1642"/>
         <location filename="../src/settings/settings_translation.cpp" line="135"/>
         <source>Go to tab 6</source>
         <translation>切换到标签 6</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="137"/>
         <source>Go to tab 7</source>
         <translation>切换到标签 7</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="139"/>
         <source>Go to tab 8</source>
         <translation>切换到标签 8</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1643"/>
         <location filename="../src/settings/settings_translation.cpp" line="141"/>
         <source>Go to tab 9</source>
         <translation>切换到标签 9</translation>
@@ -554,33 +477,31 @@
         <translation>提供调试信息资源的http文件服务器</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
+        <location filename="../src/settings/settings_translation.cpp" line="156"/>
+        <source>Allow OSC52 clipboard access</source>
+        <translation>允许OSC52剪贴板访问</translation>
+    </message>
+    <message>
         <location filename="../src/settings/settings_translation.cpp" line="69"/>
-        <location filename="../src/views/tabbar.cpp" line="486"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="208"/>
         <source>Rename title</source>
         <translation>重命名标题</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1658"/>
         <location filename="../src/settings/settings_translation.cpp" line="71"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="73"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="75"/>
         <source>Default size</source>
         <translation>默认大小</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="77"/>
         <source>Paste</source>
         <translation>粘贴</translation>
@@ -591,7 +512,6 @@
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="81"/>
         <source>Select all</source>
         <translation>全选</translation>
@@ -607,13 +527,11 @@
         <translation>跳转到上一个命令</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="87"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="89"/>
         <source>Zoom out</source>
         <translation>缩小</translation>
@@ -624,31 +542,25 @@
         <translation>关闭其他窗口</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="93"/>
-        <location filename="../src/views/termwidget.cpp" line="499"/>
         <source>Close other workspaces</source>
         <translation>关闭其他工作区</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1247"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
-        <translation>找不到 “%1”，已启动“%2”代替。请检查Shell配置。</translation>
+        <translation type="vanished">找不到 “%1”，已启动“%2”代替。请检查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1253"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
-        <translation>打不开“%1”，无法正常使用</translation>
+        <translation type="vanished">打不开“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1255"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
-        <translation>找不到“%1”，无法正常使用</translation>
+        <translation type="vanished">找不到“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1298"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
-        <translation>已经按下Ctrl+S，输出被挂起。可以按下Ctrl+Q继续。</translation>
+        <translation type="vanished">已经按下Ctrl+S，输出被挂起。可以按下Ctrl+Q继续。</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="95"/>
@@ -656,645 +568,498 @@
         <translation>关闭窗口</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1640"/>
         <location filename="../src/settings/settings_translation.cpp" line="97"/>
-        <location filename="../src/views/termwidget.cpp" line="496"/>
         <source>Close workspace</source>
         <translation>关闭工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="99"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <location filename="../src/settings/settings_translation.cpp" line="115"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1623"/>
         <location filename="../src/settings/settings_translation.cpp" line="117"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="263"/>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="627"/>
-        <location filename="../src/main/service.cpp" line="416"/>
         <source>please set another one.</source>
-        <translation>请重新设置</translation>
+        <translation type="vanished">请重新设置</translation>
     </message>
     <message>
-        <location filename="../src/main/terminalapplication.cpp" line="28"/>
         <source>Terminal is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.</source>
-        <translation>终端是一款集工作区、多窗口、远程管理、雷神模式等功能的高级终端模拟器。</translation>
+        <translation type="vanished">终端是一款集工作区、多窗口、远程管理、雷神模式等功能的高级终端模拟器。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1590"/>
         <source>Tabs</source>
-        <translation>标签页</translation>
+        <translation type="vanished">标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
-        <location filename="../src/views/tabbar.cpp" line="480"/>
         <source>Close tab</source>
-        <translation>关闭标签页</translation>
+        <translation type="vanished">关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1639"/>
         <source>Select tab</source>
-        <translation>选择标签页</translation>
+        <translation type="vanished">选择标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1610"/>
         <source>Switch focus to &quot;+&quot; icon</source>
-        <translation>光标焦点切换至“+”图标</translation>
+        <translation type="vanished">光标焦点切换至“+”图标</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="157"/>
-        <location filename="../src/main/mainwindow.cpp" line="1698"/>
         <source>Select file to upload</source>
-        <translation>选择要上传的文件</translation>
+        <translation type="vanished">选择要上传的文件</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="162"/>
-        <location filename="../src/main/mainwindow.cpp" line="1705"/>
         <source>Upload</source>
-        <translation>上传</translation>
+        <translation type="vanished">上传</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Programs are still running in terminal</source>
-        <translation>终端仍然有程序在运行</translation>
+        <translation type="vanished">终端仍然有程序在运行</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="182"/>
-        <location filename="../src/common/utils.cpp" line="216"/>
         <source>Close this terminal?</source>
-        <translation>关闭此终端？</translation>
+        <translation type="vanished">关闭此终端？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="183"/>
-        <location filename="../src/common/utils.cpp" line="217"/>
         <source>There is still a process running in this terminal. Closing the terminal will terminate it.</source>
-        <translation>该终端中仍然有1个进程在运行，关闭终端将终止进程。</translation>
+        <translation type="vanished">该终端中仍然有1个进程在运行，关闭终端将终止进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="187"/>
-        <location filename="../src/common/utils.cpp" line="221"/>
         <source>There are still %1 processes running in this terminal. Closing the terminal will terminate all of them.</source>
-        <translation>该终端中仍然有%1个进程在运行，关闭终端将终止进程。</translation>
+        <translation type="vanished">该终端中仍然有%1个进程在运行，关闭终端将终止进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="192"/>
-        <location filename="../src/common/utils.cpp" line="212"/>
         <source>Close this window?</source>
-        <translation>关闭这个窗口？</translation>
+        <translation type="vanished">关闭这个窗口？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="193"/>
-        <location filename="../src/common/utils.cpp" line="213"/>
         <source>There are still processes running in this window. Closing the window will terminate all of them.</source>
-        <translation>窗口内一些终端仍然有进程在运行，关闭窗口会终止所有进程。</translation>
+        <translation type="vanished">窗口内一些终端仍然有进程在运行，关闭窗口会终止所有进程。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="136"/>
-        <location filename="../src/main/mainwindow.cpp" line="1768"/>
         <source>Select a directory to save the file</source>
-        <translation>选择下载文件的保存目录</translation>
+        <translation type="vanished">选择下载文件的保存目录</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="230"/>
         <source>Are you sure you want to uninstall it?</source>
-        <translation>您确定要卸载它吗？</translation>
+        <translation type="vanished">您确定要卸载它吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="243"/>
-        <location filename="../src/common/utils.cpp" line="247"/>
         <source>Are you sure you want to uninstall this application?</source>
-        <translation>您确定要卸载终端吗？</translation>
+        <translation type="vanished">您确定要卸载终端吗？</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="244"/>
-        <location filename="../src/common/utils.cpp" line="248"/>
         <source>You will not be able to use Terminal any longer.</source>
-        <translation>卸载后将无法再使用该应用。</translation>
+        <translation type="vanished">卸载后将无法再使用该应用。</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="253"/>
-        <location filename="../src/views/listview.cpp" line="499"/>
-        <location filename="../src/views/listview.cpp" line="893"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="241"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="254"/>
-        <location filename="../src/common/utils.cpp" line="298"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="338"/>
         <source>Execute a command in the terminal</source>
-        <translation>在终端中运行⼀个程序</translation>
+        <translation type="vanished">在终端中运行⼀个程序</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="341"/>
         <source>Run script string in the terminal</source>
-        <translation>在终端中允许脚本字符串</translation>
+        <translation type="vanished">在终端中允许脚本字符串</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="332"/>
         <source>Set the work directory</source>
-        <translation>设置终端的启动目录</translation>
+        <translation type="vanished">设置终端的启动目录</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="335"/>
         <source>Set the window mode on starting</source>
-        <translation>设置终端开启的模式</translation>
+        <translation type="vanished">设置终端开启的模式</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="344"/>
         <source>Run in quake mode</source>
-        <translation>设置终端以雷神模式启动</translation>
+        <translation type="vanished">设置终端以雷神模式启动</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="347"/>
         <source>Keep terminal open when command finishes</source>
-        <translation>设置终端显示命令或脚本执行后的结果</translation>
+        <translation type="vanished">设置终端显示命令或脚本执行后的结果</translation>
     </message>
     <message>
-        <location filename="../src/customcommand/customcommandoptdlg.cpp" line="387"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="476"/>
         <source>The name should be no more than 32 characters</source>
-        <translation>名称长度不得超过32个字符</translation>
+        <translation type="vanished">名称长度不得超过32个字符</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="142"/>
-        <location filename="../src/main/mainwindow.cpp" line="1774"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="546"/>
         <source>Select</source>
-        <translation>选择</translation>
+        <translation type="vanished">选择</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="542"/>
         <source>Select the private key file</source>
-        <translation>选择私钥文件</translation>
+        <translation type="vanished">选择私钥文件</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="121"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
         <source>Tab title format</source>
         <translation>标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="123"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>Remote tab title format</source>
         <translation>远程标签标题格式</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1638"/>
-        <location filename="../src/views/tabbar.cpp" line="483"/>
         <source>Close other tabs</source>
-        <translation>关闭其他标签页</translation>
+        <translation type="vanished">关闭其他标签页</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="894"/>
         <source>Delete</source>
         <comment>button</comment>
-        <translation>删 除</translation>
+        <translation type="vanished">删 除</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="500"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="245"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="210"/>
         <source>Add Group</source>
-        <translation>添加分组</translation>
+        <translation type="vanished">添加分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="211"/>
         <source>Add Server</source>
-        <translation>添加服务器</translation>
+        <translation type="vanished">添加服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="215"/>
         <source>No servers yet</source>
-        <translation>未添加服务器</translation>
+        <translation type="vanished">未添加服务器</translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementPlugin</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="75"/>
         <source>Remote management</source>
-        <translation>远程管理</translation>
+        <translation type="vanished">远程管理</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementplugn.cpp" line="201"/>
         <source>Make sure that rz and sz commands have been installed in the server before right clicking to upload and download files.</source>
-        <translation>在您使用右键菜单进行上传和下载文件之前， 请先确保服务器已经安装了 rz和sz 命令。</translation>
+        <translation type="vanished">在您使用右键菜单进行上传和下载文件之前， 请先确保服务器已经安装了 rz和sz 命令。</translation>
     </message>
 </context>
 <context>
     <name>RemoteManagementSearchPanel</name>
     <message>
-        <location filename="../src/remotemanage/remotemanagementsearchpanel.cpp" line="211"/>
         <source>Search</source>
-        <translation>搜索</translation>
+        <translation type="vanished">搜索</translation>
     </message>
 </context>
 <context>
     <name>ServerConfigManager</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigmanager.cpp" line="87"/>
         <source>Groups</source>
-        <translation>服务器组</translation>
+        <translation type="vanished">服务器组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigmanager.cpp" line="88"/>
         <source>Servers</source>
-        <translation>服务器</translation>
+        <translation type="vanished">服务器</translation>
     </message>
 </context>
 <context>
     <name>ServerConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="91"/>
         <source>Add Server</source>
-        <translation>添加服务器</translation>
+        <translation type="vanished">添加服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="127"/>
         <source>Server name:</source>
-        <translation>服务器名：</translation>
+        <translation type="vanished">服务器名：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="129"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="139"/>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="167"/>
         <source>Required</source>
-        <translation>必填</translation>
+        <translation type="vanished">必填</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="137"/>
         <source>Address:</source>
-        <translation>地址：</translation>
+        <translation type="vanished">地址：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="144"/>
         <source>Port:</source>
-        <translation>端口：</translation>
+        <translation type="vanished">端口：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="165"/>
         <source>Username:</source>
-        <translation>用户名：</translation>
+        <translation type="vanished">用户名：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="172"/>
         <source>Password:</source>
-        <translation>密码：</translation>
+        <translation type="vanished">密码：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="178"/>
         <source>Certificate:</source>
-        <translation>证书：</translation>
+        <translation type="vanished">证书：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="185"/>
         <source>Group:</source>
-        <translation>分组：</translation>
+        <translation type="vanished">分组：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="189"/>
         <source>No Group</source>
-        <translation>无分组</translation>
+        <translation type="vanished">无分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="193"/>
         <source>Path:</source>
-        <translation>路径：</translation>
+        <translation type="vanished">路径：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="199"/>
         <source>Command:</source>
-        <translation>命令：</translation>
+        <translation type="vanished">命令：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="205"/>
         <source>Encoding:</source>
-        <translation>编码：</translation>
+        <translation type="vanished">编码：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="211"/>
         <source>Backspace key:</source>
-        <translation>退格键：</translation>
+        <translation type="vanished">退格键：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="217"/>
         <source>Delete key:</source>
-        <translation>删除键：</translation>
+        <translation type="vanished">删除键：</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="223"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="224"/>
         <source>Add</source>
         <comment>button</comment>
-        <translation>添 加</translation>
+        <translation type="vanished">添 加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="228"/>
         <source>Edit Server</source>
-        <translation>编辑服务器</translation>
+        <translation type="vanished">编辑服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="229"/>
         <source>Save</source>
         <comment>button</comment>
-        <translation>保 存</translation>
+        <translation type="vanished">保 存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="470"/>
         <source>Please enter a server name</source>
-        <translation>请输入服务器名称</translation>
+        <translation type="vanished">请输入服务器名称</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="483"/>
         <source>Please enter an IP address</source>
-        <translation>请输入IP地址</translation>
+        <translation type="vanished">请输入IP地址</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="488"/>
         <source>Please enter a port</source>
-        <translation>请输入端口</translation>
+        <translation type="vanished">请输入端口</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="494"/>
         <source>Please enter a username</source>
-        <translation>请输入用户名</translation>
+        <translation type="vanished">请输入用户名</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="508"/>
         <source>The server name already exists,</source>
-        <translation>该服务器名已存在，</translation>
+        <translation type="vanished">该服务器名已存在，</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="509"/>
         <source>please input another one. </source>
-        <translation>请重新输入</translation>
+        <translation type="vanished">请重新输入</translation>
     </message>
 </context>
 <context>
     <name>Service</name>
     <message>
-        <location filename="../src/main/service.cpp" line="412"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
 </context>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
         <source>Split screen</source>
-        <translation>分屏</translation>
+        <translation type="vanished">分屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
         <source>Fullscreen</source>
-        <translation>全屏</translation>
+        <translation type="vanished">全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
         <source>Normal window</source>
-        <translation>正常窗口</translation>
+        <translation type="vanished">正常窗口</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="130"/>
         <source>Maximum</source>
-        <translation>最大化</translation>
+        <translation type="vanished">最大化</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="722"/>
         <source>Fast</source>
-        <translation>快</translation>
+        <translation type="vanished">快</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="726"/>
         <source>Slow</source>
-        <translation>慢</translation>
+        <translation type="vanished">慢</translation>
     </message>
 </context>
 <context>
     <name>ShortcutManager</name>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="268"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="277"/>
         <source>The shortcut %1 is invalid, </source>
-        <translation>%1为无效快捷键，</translation>
+        <translation type="vanished">%1为无效快捷键，</translation>
     </message>
     <message>
-        <location filename="../src/settings/shortcutmanager.cpp" line="284"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="291"/>
-        <location filename="../src/settings/shortcutmanager.cpp" line="297"/>
         <source>The shortcut %1 was already in use, </source>
-        <translation>快捷键%1已被占用，</translation>
+        <translation type="vanished">快捷键%1已被占用，</translation>
     </message>
 </context>
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="42"/>
         <source>Insert</source>
-        <translation>插入</translation>
+        <translation type="vanished">插入</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="88"/>
         <source>username: %u</source>
-        <translation>用户名：%u</translation>
+        <translation type="vanished">用户名：%u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
         <source>username@: %U</source>
-        <translation>用户名@：%U</translation>
+        <translation type="vanished">用户名@：%U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="74"/>
         <source>remote host: %h</source>
-        <translation>远程主机：%h</translation>
+        <translation type="vanished">远程主机：%h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="75"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="87"/>
         <source>session number: %#</source>
-        <translation>会话编号：%#</translation>
+        <translation type="vanished">会话编号：%#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="75"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="89"/>
         <source>title set by shell: %w</source>
-        <translation>shell设定的窗口标题：%w</translation>
+        <translation type="vanished">shell设定的窗口标题：%w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="86"/>
         <source>program name: %n</source>
-        <translation>程序名：%n</translation>
+        <translation type="vanished">程序名：%n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="86"/>
         <source>current directory (short): %d</source>
-        <translation>当前目录（短）：%d</translation>
+        <translation type="vanished">当前目录（短）：%d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="87"/>
         <source>current directory (long): %D</source>
-        <translation>当前目录（长）：%D</translation>
+        <translation type="vanished">当前目录（长）：%D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="88"/>
         <source>local host: %h</source>
-        <translation>本地主机：%h</translation>
+        <translation type="vanished">本地主机：%h</translation>
     </message>
 </context>
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="469"/>
         <source>Copy</source>
-        <translation>复制</translation>
+        <translation type="vanished">复制</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="472"/>
         <source>Paste</source>
-        <translation>粘贴</translation>
+        <translation type="vanished">粘贴</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="481"/>
         <source>Open</source>
-        <translation>打开</translation>
+        <translation type="vanished">打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="485"/>
         <source>Open in file manager</source>
-        <translation>在文件管理器中打开</translation>
+        <translation type="vanished">在文件管理器中打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="490"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>Horizontal split</source>
-        <translation>横向分屏</translation>
+        <translation type="vanished">横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="492"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>Vertical split</source>
-        <translation>纵向分屏</translation>
+        <translation type="vanished">纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="503"/>
-        <location filename="../src/views/termwidget.cpp" line="549"/>
         <source>New tab</source>
-        <translation>新建标签页</translation>
+        <translation type="vanished">新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="510"/>
         <source>Exit fullscreen</source>
-        <translation>退出全屏</translation>
+        <translation type="vanished">退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="512"/>
         <source>Fullscreen</source>
-        <translation>全屏</translation>
+        <translation type="vanished">全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="515"/>
         <source>Find</source>
-        <translation>查找</translation>
+        <translation type="vanished">查找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="519"/>
         <source>Search</source>
-        <translation>搜索</translation>
+        <translation type="vanished">搜索</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="529"/>
         <source>Encoding</source>
-        <translation>编码</translation>
+        <translation type="vanished">编码</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="531"/>
         <source>Custom commands</source>
-        <translation>自定义命令</translation>
+        <translation type="vanished">自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="533"/>
         <source>Remote management</source>
-        <translation>远程管理</translation>
+        <translation type="vanished">远程管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="537"/>
         <source>Upload file</source>
-        <translation>上传文件</translation>
+        <translation type="vanished">上传文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="538"/>
         <source>Download file</source>
-        <translation>下载文件</translation>
+        <translation type="vanished">下载文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="543"/>
         <source>Settings</source>
-        <translation>设置</translation>
+        <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1200"/>
         <source>The debuginfod settings will be effective after restart</source>
-        <translation>debuginfod设置，重启终端后生效</translation>
+        <translation type="vanished">debuginfod设置，重启终端后生效</translation>
     </message>
 </context>
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../src/common/utils.cpp" line="198"/>
-        <location filename="../src/common/utils.cpp" line="232"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation>取 消</translation>
+        <translation type="vanished">取 消</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="200"/>
         <source>Close</source>
         <comment>button</comment>
-        <translation>关 闭</translation>
+        <translation type="vanished">关 闭</translation>
     </message>
     <message>
-        <location filename="../src/common/utils.cpp" line="233"/>
-        <location filename="../src/common/utils.cpp" line="265"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation>确 定</translation>
+        <translation type="vanished">确 定</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
- Add allow_osc52 configuration option in settings
- Implement OSC52 escape sequence parsing in Vt102Emulation
- Add clipboard handling in TermWidget with security checks
- Support CLIPBOARD, PRIMARY, and SECONDARY clipboards
- Add data size limit (1MB) and Base64/UTF-8 validation
- Update translations for OSC52 setting

Features:
- Terminal applications can now access clipboard via OSC52
- User can enable/disable OSC52 in settings
- Automatic PRIMARY clipboard sync when 'Copy on select' is enabled

Security:
- Configurable access control
- Data size limit to prevent DoS
- Input validation for Base64 and UTF-8

Translations:
- Added Chinese translation: 允许 OSC52 剪贴板访问
- Updated deepin-terminal.ts and deepin-terminal_zh_CN.ts