### PR TITLE
feat: enable treeland singleton flag for deepin-terminal

### DIFF
--- a/src/deepin-terminal.desktop
+++ b/src/deepin-terminal.desktop
@@ -10,6 +10,7 @@ StartupNotify=false
 TryExec=deepin-terminal
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 Actions=new-window;quake-mode;
 MimeType=x-scheme-handler/dsg-terminal-exec
 


### PR DESCRIPTION
For singleton applications, a splash screen should not be displayed on the second launch. We declare ourselves as a singleton application by adding the `X-Deepin-Singleton` field, thus avoiding unnecessary splash screens on Treeland.

单例应用第二次启动时不应该显示闪屏,通过添加 X-Deepin-Singleton 字段声明自己属于单例应用， 防止 treeland 上显示多余的闪屏。

Ref: https://github.com/linuxdeepin/dde-application-manager/pull/329