### PR TITLE
feat: implement OSC52 remote clipboard functionality

### DIFF
--- a/3rdparty/terminalwidget/lib/Emulation.h
+++ b/3rdparty/terminalwidget/lib/Emulation.h
@@ -475,6 +475,21 @@ signals:
      */
     void cursorChanged(KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 
+    /**
+     * @brief OSC52 clipboard operation request
+     *
+     * Emitted when a terminal program sends OSC52 escape sequence.
+     * Format: ESC ] 52 ; target ; base64-data BEL
+     *
+     * @param target Clipboard target:
+     *        - 'c' = CLIPBOARD (system clipboard, Ctrl+C/V)
+     *        - 'p' = PRIMARY (X11 primary selection, middle-click paste)
+     *        - 's' = SECONDARY (X11 secondary selection)
+     *        - '0' = All clipboards
+     * @param base64Data Base64-encoded clipboard data
+     */
+    void osc52ClipboardRequest(char target, const QString &base64Data);
+
 protected:
     virtual void setMode(int mode) = 0;
     virtual void resetMode(int mode) = 0;

--- a/3rdparty/terminalwidget/lib/Screen.cpp
+++ b/3rdparty/terminalwidget/lib/Screen.cpp
@@ -829,7 +829,21 @@ void Screen::displayCharacter(uint c)
         w--;
     }
     _cuX = newCursorX;
-    _escapeSequenceUrlExtractor->appendUrlText(QChar(c));
+
+    if (c <= 0xFFFF) {
+        _escapeSequenceUrlExtractor->appendUrlText(QChar(static_cast<ushort>(c)));
+    } else {
+        // 对于超过 0xFFFF 的字符，需要拆分为高代理和低代理
+        // 注意：如果 appendUrlText 逻辑依赖于“一个调用代表一个完整字符”，
+        // 这里分两次调用可能会破坏其内部逻辑（如 URL 提取）。
+        // 最好的办法依然是修改 appendUrlText 接受 QString。
+        QChar high = QChar::highSurrogate(c);
+        QChar low = QChar::lowSurrogate(c);
+
+        // 尝试连续调用，但这取决于 appendUrlText 的具体实现
+        _escapeSequenceUrlExtractor->appendUrlText(high);
+        _escapeSequenceUrlExtractor->appendUrlText(low);
+    }
 }
 
 void Screen::compose(const QString& /*compose*/)

--- a/3rdparty/terminalwidget/lib/Session.cpp
+++ b/3rdparty/terminalwidget/lib/Session.cpp
@@ -113,6 +113,10 @@ Session::Session(QObject* parent) :
     //connect teletype to emulation backend
     _shellProcess->setUtf8Mode(_emulation->utf8());
 
+    // OSC52
+    connect(_emulation, SIGNAL(osc52ClipboardRequest(char,QString)),
+            this, SIGNAL(osc52ClipboardRequest(char,QString)));
+
     connect( _shellProcess,SIGNAL(receivedData(const char *,int,bool)),this,
              SLOT(onReceiveBlock(const char *,int,bool)) );
     connect( _emulation,SIGNAL(sendData(const char *,int,const QTextCodec *)),_shellProcess,

--- a/3rdparty/terminalwidget/lib/Session.h
+++ b/3rdparty/terminalwidget/lib/Session.h
@@ -557,6 +557,9 @@ signals:
     // warning提示信息 currentShell当前使用的shell, 启用shell是否成功 true 替换了shell false 替换shell但启动失败
     void shellWarningMessage(QString currentShell, bool isSuccess);
 
+    // OSC52 clipboard operation request
+    void osc52ClipboardRequest(char target, const QString &base64Data);
+
 private slots:
     void done(int);
 

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -205,6 +205,12 @@ void Vt102Emulation::addToCurrentToken(wchar_t cc)
 {
   tokenBuffer[tokenBufferPos] = cc;
   tokenBufferPos = qMin(tokenBufferPos+1,MAX_TOKEN_LENGTH-1);
+
+  // ========== OSC52: Check accumulated buffer size ==========
+  if (_osc52InProgress && tokenBufferPos >= MAX_TOKEN_LENGTH - 100) {
+      handleOSC52Chunk();
+  }
+  // ==========================================================
 }
 
 // Character Class flags used while decoding
@@ -278,12 +284,29 @@ void Vt102Emulation::initTokenizer()
 #define CNTL(c) ((c)-'@')
 #define ESC 27
 #define DEL 127
+#define BEL 7
 
 // process an incoming unicode character
 void Vt102Emulation::receiveChar(wchar_t cc)
 {
   if (cc == DEL)
     return; //VT100: ignore.
+
+  // ==========  OSC52: Direct path for subsequent chunks ==========
+  // If OSC52 is in progress and past first chunk, directly accumulate
+  if (_osc52InProgress && cc != BEL) {
+      addToCurrentToken(cc);
+      // Chunk boundary check is handled inside addToCurrentToken()
+      return;
+  }
+  // ========== OSC52: Check for BEL end ==========
+  // CRITICAL: Remove Xpe check - BEL alone should end OSC52 sequence
+  if (cc == BEL && _osc52InProgress) {
+      handleOSC52End(cc);
+      resetTokenizer();
+      return;
+  }
+  // =======================================================
 
   if (ces(CTL))
   {
@@ -317,8 +340,26 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(1,0,ESC)) { return; }
     if (lec(1,0,ESC+128)) { s[0] = ESC; receiveChar('['); return; }
     if (les(2,1,GRP)) { return; }
-    if (Xte         ) { processWindowAttributeChange(); resetTokenizer(); return; }
-    if (Xpe         ) { prevCC = cc; return; }
+    // ========== OSC: Unified handling ==========
+    if (Xpe && !_osc52InProgress) {
+        // Check 1: OSC52 start detection
+        if (isOSC52Start()) {
+            startOSC52();
+            // Don't return - continue to accumulate
+        }
+        // Check 2: OSC end (BEL or ST)
+        else if (cc == BEL || (prevCC == ESC && cc == 0x5C)) {
+            processWindowAttributeChange();
+            resetTokenizer();
+            return;
+        }
+        // Check 3: Normal OSC - accumulate
+        else {
+            prevCC = cc;
+            return;
+        }
+    }
+    // ============================================
     if (lec(3,2,'?')) { return; }
     if (lec(3,2,'>')) { return; }
     if (lec(3,2,'!')) { return; }
@@ -916,6 +957,127 @@ void Vt102Emulation::reportTerminalParms(int p)
   }
   sendString(tmp);
 }
+
+// ========== OSC52 Clipboard Implementation ==========
+
+bool Vt102Emulation::isOSC52Start() const
+{
+    // Check if tokenBuffer starts with "ESC ] 5 2 ;"
+    // tokenBuffer layout: [0]=ESC, [1]=']', [2]='5', [3]='2', [4]=';'
+    return (tokenBufferPos >= 5 &&
+            tokenBuffer[2] == L'5' &&
+            tokenBuffer[3] == L'2' &&
+            tokenBuffer[4] == L';');
+}
+
+char Vt102Emulation::extractOSC52Target() const
+{
+    // tokenBuffer layout: ESC ] 5 2 ; target ; base64...
+    //                                     ↑
+    //                                  position 5
+    if (tokenBufferPos > 5) {
+        return static_cast<char>(tokenBuffer[5]);
+    }
+    return 'c'; // Default to CLIPBOARD
+}
+
+QString Vt102Emulation::extractOSC52Data() const
+{
+    // tokenBuffer layout: ESC ] 5 2 ; target ; base64...
+    //                                       ↑
+    //                                    position 7 (data start for first chunk)
+    // For subsequent chunks, data starts at position 0
+    int dataStart = _osc52IsFirstChunk ? 7 : 0;
+    if (tokenBufferPos > dataStart) {
+        return QString::fromWCharArray(tokenBuffer + dataStart, tokenBufferPos - dataStart);
+    }
+    return QString();
+}
+
+void Vt102Emulation::startOSC52()
+{
+    _osc52InProgress = true;
+    _osc52Target = extractOSC52Target();
+    _osc52DataBuffer.clear();
+    _osc52IsFirstChunk = true;  // Mark as first chunk
+
+    qInfo() << "OSC52: Start, target=" << _osc52Target;
+}
+
+void Vt102Emulation::handleOSC52End(wchar_t cc)
+{
+    // cc should be BEL (7)
+    Q_ASSERT(cc == BEL);
+    Q_UNUSED(cc);
+
+    // Extract base64 data from current tokenBuffer
+    // For the final chunk, skip BEL character at the end
+    QString base64Data;
+    if (_osc52IsFirstChunk) {
+        // Single chunk OSC52: skip header (7 chars) and BEL (1 char)
+        if (tokenBufferPos > 8) {
+            base64Data = QString::fromWCharArray(tokenBuffer + 7, tokenBufferPos - 8);
+        }
+    } else {
+        // Multi-chunk OSC52 final chunk: tokenBuffer contains ONLY base64 data
+        // tokenBufferPos includes the BEL character, so subtract 1
+        if (tokenBufferPos > 1) {
+            base64Data = QString::fromWCharArray(tokenBuffer, tokenBufferPos - 1);
+        }
+    }
+
+    // Accumulate to buffer
+    _osc52DataBuffer += base64Data;
+
+    // ========== OSC52: Check final buffer size ==========
+    if (_osc52DataBuffer.size() >= MAX_OSC52_BUFFER) {
+        qWarning() << "OSC52: Buffer overflow (>=" << MAX_OSC52_BUFFER
+                   << "bytes), rejecting";
+        _osc52DataBuffer.clear();
+        _osc52InProgress = false;
+        _osc52IsFirstChunk = false;
+        return;
+    }
+    // ====================================================
+
+    // Emit signal with complete data
+    emit osc52ClipboardRequest(_osc52Target, _osc52DataBuffer);
+
+    qInfo() << "OSC52: Complete, sent" << _osc52DataBuffer.size() << "bytes";
+
+    // Clear state
+    _osc52DataBuffer.clear();
+    _osc52InProgress = false;
+    _osc52IsFirstChunk = false;
+}
+
+void Vt102Emulation::handleOSC52Chunk()
+{
+    // ========== OSC52: Check buffer size limit ==========
+    if (_osc52DataBuffer.size() >= MAX_OSC52_BUFFER) {
+        qWarning() << "OSC52: Buffer overflow (>=" << MAX_OSC52_BUFFER
+                   << "bytes), rejecting";
+        _osc52DataBuffer.clear();
+        _osc52InProgress = false;
+        _osc52IsFirstChunk = false;
+        return;
+    }
+    // ====================================================
+
+    // Extract current chunk from tokenBuffer
+    QString base64Data = extractOSC52Data();
+    _osc52DataBuffer += base64Data;
+
+    // Mark as not first chunk for subsequent chunks
+    _osc52IsFirstChunk = false;
+
+    // ========== Add resetTokenizer ==========
+    resetTokenizer();  // 清空 tokenBuffer，准备接收新数据
+    // ========================================
+    // Don't clear state, continue receiving
+}
+
+// ====================================================
 
 void Vt102Emulation::reportStatus()
 {

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.h
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.h
@@ -51,6 +51,8 @@
 #define MODE_BracketedPaste  (MODES_SCREEN+13)  // Xterm-style bracketed paste mode
 #define MODE_total           (MODES_SCREEN+14)
 
+static const size_t MAX_OSC52_BUFFER = 64 * 1024 * 1024;  // 64MB
+
 namespace Konsole
 {
 
@@ -166,6 +168,42 @@ private:
   void onScrollLock();
   void scrollLock(const bool lock);
 
+  // ========== OSC52 Clipboard Methods ==========
+  /**
+   * @brief Check if current OSC sequence is OSC52 clipboard
+   * @return true if OSC52 start detected
+   */
+  bool isOSC52Start() const;
+
+  /**
+   * @brief Extract target clipboard character from tokenBuffer
+   * @return target character (c/p/s/0)
+   */
+  char extractOSC52Target() const;
+
+  /**
+   * @brief Extract base64 data from tokenBuffer
+   * @return base64 encoded data
+   */
+  QString extractOSC52Data() const;
+
+  /**
+   * @brief Start OSC52 clipboard sequence processing
+   */
+  void startOSC52();
+
+  /**
+   * @brief Handle OSC52 end (BEL character received)
+   * @param cc The BEL character (should be 7)
+   */
+  void handleOSC52End(wchar_t cc);
+
+  /**
+   * @brief Handle OSC52 chunk when tokenBuffer is full
+   */
+  void handleOSC52Chunk();
+  // ===============================================
+
   // clears the screen and resizes it to the specified
   // number of columns
   void clearScreenAndSetColumns(int columnCount);
@@ -194,6 +232,28 @@ private:
   QTimer* _titleUpdateTimer;
 
     bool _reportFocusEvents;
+
+    // ========== OSC52 Clipboard Support ==========
+    /**
+    * @brief Flag indicating if OSC52 clipboard sequence is in progress
+    */
+    bool _osc52InProgress = false;
+
+    /**
+      * @brief Buffer for accumulating OSC52 base64 data
+      */
+    QString _osc52DataBuffer;
+
+    /**
+      * @brief Target clipboard for OSC52 (c=CLIPBOARD, p=PRIMARY, s=SECONDARY, 0=ALL)
+      */
+    char _osc52Target = 'c';
+
+    /**
+      * @brief Flag indicating if current OSC52 chunk is the first chunk
+      */
+    bool _osc52IsFirstChunk = false;
+    // ==============================================
 };
 
 }

--- a/3rdparty/terminalwidget/lib/qtermwidget.cpp
+++ b/3rdparty/terminalwidget/lib/qtermwidget.cpp
@@ -514,6 +514,10 @@ void QTermWidget::init(int startnow)
 
     //将终端活动状态传给SessionManager单例
     connect(this, SIGNAL(isTermIdle(bool)), SessionManager::instance(), SIGNAL(sessionIdle(bool)));
+
+    // Connect OSC52 signal from emulation
+    connect(m_impl->m_session, SIGNAL(osc52ClipboardRequest(char,QString)),
+            this, SIGNAL(osc52ClipboardRequest(char,QString)));
 }
 
 QTermWidget::~QTermWidget()

--- a/3rdparty/terminalwidget/lib/qtermwidget.h
+++ b/3rdparty/terminalwidget/lib/qtermwidget.h
@@ -346,6 +346,11 @@ signals:
     // 标签标题参数改变 dzw 2020-12-2
     void titleArgsChange(QString key, QString value);
 
+    /**
+     * @brief Forward OSC52 clipboard request from Emulation
+     */
+    void osc52ClipboardRequest(char target, const QString &base64Data);
+
 public slots:
     // Copy selection to clipboard
     void copyClipboard();

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -337,6 +337,12 @@
                             "default": true
                         },
                         {
+                            "key": "allow_osc52",
+                            "type": "checkbox",
+                            "text": "Allow OSC52 clipboard access",
+                            "default": true
+                        },
+                        {
                             "key": "set_cursor_position",
                             "type": "checkbox",
                             "text": "Allow Ctrl + left mouse click to set cursor position",

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -340,7 +340,7 @@
                             "key": "allow_osc52",
                             "type": "checkbox",
                             "text": "Allow OSC52 clipboard access",
-                            "default": true
+                            "default": false
                         },
                         {
                             "key": "set_cursor_position",

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -729,6 +729,11 @@ QString Settings::debuginfodUrls()
     return settings->option("advanced.debuginfod.debuginfod_urls")->value().toString();
 }
 
+bool Settings::allowOSC52() const
+{
+    return settings->option("advanced.cursor.allow_osc52")->value().toBool();
+}
+
 /******** Add by ut001000 renfeixiang 2020-06-15:增加 每次显示设置界面时，更新设置的等宽字体 End***************/
 
 /*******************************************************************************

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -216,6 +216,12 @@ public:
     bool enableDebuginfod();
     // deepin-terminal设置的DEBUGINFOD_URLS环境变量值
     QString debuginfodUrls();
+    /**
+     * @brief 获取当前配置粘贴是否为选择内容
+     * @author dzw1995
+     * @return
+     */
+    bool allowOSC52() const;
 
     /**
      * @brief 历史记录行数

--- a/src/settings/settings_translation.cpp
+++ b/src/settings/settings_translation.cpp
@@ -159,4 +159,8 @@ void GenerateSettingTranslate()
     Q_UNUSED(set_cursor_position);
     auto enable_debuginfod = QObject::tr("The HTTP file server used for transmitting debugging information resources");
     Q_UNUSED(enable_debuginfod);
+
+    // OSC52 clipboard
+    auto advanced_cursor_allow_osc52Text = QObject::tr("Allow OSC52 clipboard access");
+    Q_UNUSED(advanced_cursor_allow_osc52Text);
 }

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -254,6 +254,10 @@ void TermWidget::initConnections()
     connect(Service::instance(), &Service::touchPadEventSignal, this, &TermWidget::onTouchPadSignal);
 
     connect(Service::instance(), &Service::hostnameChanged, this, &TermWidget::onHostnameChanged);
+
+    // Connect OSC52 signal
+    connect(this, &QTermWidget::osc52ClipboardRequest,
+            this, &TermWidget::handleOSC52Clipboard);
 }
 
 inline void TermWidget::onSetTerminalFont()
@@ -1385,6 +1389,90 @@ void TermWidget::onShellMessage(QString currentShell, bool isSuccess)
 
         showShellMessage(strShellNoFound);
     }
+}
+
+void TermWidget::handleOSC52Clipboard(char target, const QString &base64Data)
+{
+    // ========== Security Check 1: User Settings ==========
+    if (!Settings::instance()->allowOSC52()) {
+        qWarning() << "OSC52: Blocked by user settings (allowOSC52=false)";
+        return;
+    }
+
+    // ========== Security Check 2: Data Size Limit ==========
+    const int MAX_CLIPBOARD_SIZE = 64 * 1024 * 1024;  // 64MB Base64编码后的内容
+
+    if (base64Data.size() > MAX_CLIPBOARD_SIZE) {
+        qWarning().nospace() << "OSC52: Rejected - data too large ("
+                             << base64Data.size()
+                             << " bytes, max=" << MAX_CLIPBOARD_SIZE << ")";
+        return;
+    }
+
+    // ========== Base64 Decode ==========
+    QByteArray decoded;
+
+    if (base64Data.isEmpty()) {
+        // Empty data: clear clipboard
+        decoded = QByteArray();
+    } else {
+        // Normal Base64 decode
+        decoded = QByteArray::fromBase64(base64Data.toLatin1());
+
+        // Check decode failure
+        if (decoded.isEmpty() && !base64Data.isEmpty()) {
+            qWarning() << "OSC52: Base64 decoding failed for data:"
+                       << base64Data.left(50) << "...";
+            return;
+        }
+    }
+
+    // ========== UTF-8 Decode ==========
+    QString text = QString::fromUtf8(decoded);
+
+    if (text.isEmpty() && !decoded.isEmpty()) {
+        qWarning() << "OSC52: Invalid UTF-8 encoding in clipboard data";
+        return;
+    }
+
+    // ========== Write to System Clipboard ==========
+    QClipboard *clipboard = QApplication::clipboard();
+
+    qInfo().nospace() << "OSC52: Writing " << text.size()
+                      << " bytes to clipboard (target: " << target << ")";
+
+    switch (target) {
+        case 'p':
+            // PRIMARY selection (X11 middle-click paste)
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case 's':
+            // SECONDARY selection (X11, rarely used)
+            // Qt doesn't directly support SECONDARY, use Selection
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case '0':
+            // All clipboards
+            clipboard->setText(text, QClipboard::Clipboard);
+            clipboard->setText(text, QClipboard::Selection);
+            break;
+
+        case 'c':
+        default:
+            // CLIPBOARD (system clipboard, Ctrl+C/V)
+            clipboard->setText(text, QClipboard::Clipboard);
+
+            // If "Copy on select" is enabled, also write to PRIMARY
+            // This allows middle-click paste for OSC52 content
+            if (Settings::instance()->IsPasteSelection()) {
+                clipboard->setText(text, QClipboard::Selection);
+            }
+            break;
+    }
+
+    qInfo() << "OSC52: Successfully copied to clipboard";
 }
 
 void TermWidget::wheelEvent(QWheelEvent *event)

--- a/src/views/termwidget.h
+++ b/src/views/termwidget.h
@@ -297,6 +297,16 @@ public slots:
      */
     void onShellMessage(QString currentShell, bool isSuccess);
 
+    /**
+     * @brief Handle OSC52 clipboard request
+     * @param target Clipboard target ('c', 'p', 's', '0')
+     * @param base64Data Base64-encoded data
+     *
+     * @author dzw1995
+     * @date 2026-03-14
+     */
+    void handleOSC52Clipboard(char target, const QString &base64Data);
+
 signals:
     void termRequestRenameTab(QString newTabName);
     void termIsIdle(QString tabIdentifier, bool bIdle);

--- a/translations/deepin-terminal.ts
+++ b/translations/deepin-terminal.ts
@@ -173,42 +173,42 @@
 <context>
     <name>GroupConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="38"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="39"/>
         <source>Group Name(Required)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="40"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="41"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="43"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="44"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="59"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="64"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="65"/>
         <source>Please enter a group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="68"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="69"/>
         <source>The name should be no more than 30 characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -216,7 +216,7 @@
 <context>
     <name>Konsole::Session</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Session.cpp" line="763"/>
+        <location filename="../3rdparty/terminalwidget/lib/Session.cpp" line="767"/>
         <source>Press any keys to exit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -224,17 +224,17 @@
 <context>
     <name>Konsole::TerminalDisplay</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1295"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1359"/>
         <source>Size: XXX x XXX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1318"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1382"/>
         <source>Size: %1 x %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="3651"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="3729"/>
         <source>&lt;qt&gt;Output has been &lt;a href=&quot;http://en.wikipedia.org/wiki/Flow_control&quot;&gt;suspended&lt;/a&gt; by pressing Ctrl+S.  Press &lt;b&gt;Ctrl+Q&lt;/b&gt; to resume.&lt;/qt&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -242,7 +242,7 @@
 <context>
     <name>Konsole::Vt102Emulation</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Vt102Emulation.cpp" line="1116"/>
+        <location filename="../3rdparty/terminalwidget/lib/Vt102Emulation.cpp" line="1278"/>
         <source>No keyboard translator available.  The information needed to convert key presses into characters to send to the terminal is missing.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,29 +251,29 @@
     <name>ListView</name>
     <message>
         <location filename="../src/views/listview.cpp" line="343"/>
-        <location filename="../src/views/listview.cpp" line="1020"/>
+        <location filename="../src/views/listview.cpp" line="1022"/>
         <source>Delete Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="343"/>
         <location filename="../src/views/listview.cpp" line="589"/>
-        <location filename="../src/views/listview.cpp" line="1030"/>
+        <location filename="../src/views/listview.cpp" line="1034"/>
         <source>Are you sure you want to delete %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1022"/>
+        <location filename="../src/views/listview.cpp" line="1024"/>
         <source>Delete Custom Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1025"/>
+        <location filename="../src/views/listview.cpp" line="1027"/>
         <source>Cancel Server Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1032"/>
+        <location filename="../src/views/listview.cpp" line="1036"/>
         <source>Ungrouped servers will go back to server list!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -281,35 +281,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="300"/>
-        <location filename="../src/main/mainwindow.cpp" line="368"/>
+        <location filename="../src/main/mainwindow.cpp" line="334"/>
+        <location filename="../src/main/mainwindow.cpp" line="402"/>
         <source>New window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="389"/>
+        <location filename="../src/main/mainwindow.cpp" line="423"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="897"/>
+        <location filename="../src/main/mainwindow.cpp" line="931"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="899"/>
+        <location filename="../src/main/mainwindow.cpp" line="933"/>
         <source>Close</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2077"/>
+        <location filename="../src/main/mainwindow.cpp" line="2099"/>
         <source>Type path to download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2403"/>
+        <location filename="../src/main/mainwindow.cpp" line="2491"/>
         <source>Custom Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -320,89 +320,89 @@
         <location filename="../src/common/utils.cpp" line="291"/>
         <location filename="../src/views/listview.cpp" line="349"/>
         <location filename="../src/views/listview.cpp" line="590"/>
-        <location filename="../src/views/listview.cpp" line="1043"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="286"/>
+        <location filename="../src/views/listview.cpp" line="1047"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="341"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="350"/>
-        <location filename="../src/views/listview.cpp" line="1044"/>
+        <location filename="../src/views/listview.cpp" line="1048"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="591"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="291"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="346"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="102"/>
-        <location filename="../src/views/termwidget.cpp" line="575"/>
+        <location filename="../src/views/termwidget.cpp" line="584"/>
         <source>Close workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="98"/>
-        <location filename="../src/views/termwidget.cpp" line="578"/>
+        <location filename="../src/views/termwidget.cpp" line="587"/>
         <source>Close other workspaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1349"/>
+        <location filename="../src/views/termwidget.cpp" line="1376"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1357"/>
+        <location filename="../src/views/termwidget.cpp" line="1384"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1360"/>
+        <location filename="../src/views/termwidget.cpp" line="1387"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1402"/>
+        <location filename="../src/views/termwidget.cpp" line="1513"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="126"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="145"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="147"/>
         <source>Tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="128"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="148"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="150"/>
         <source>Remote tab title format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="74"/>
-        <location filename="../src/views/tabbar.cpp" line="611"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="246"/>
+        <location filename="../src/views/tabbar.cpp" line="656"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="301"/>
         <source>Rename title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
-        <location filename="../src/views/tabbar.cpp" line="605"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
+        <location filename="../src/views/tabbar.cpp" line="650"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
-        <location filename="../src/views/tabbar.cpp" line="608"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
+        <location filename="../src/views/tabbar.cpp" line="653"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -539,13 +539,19 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1915"/>
+        <location filename="../src/settings/settings_translation.cpp" line="164"/>
+        <source>Allow OSC52 clipboard access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main/mainwindow.cpp" line="1937"/>
         <location filename="../src/settings/settings_translation.cpp" line="62"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1913"/>
+        <location filename="../src/main/mainwindow.cpp" line="1935"/>
+        <location filename="../src/main/mainwindow.cpp" line="2911"/>
         <location filename="../src/main/terminalapplication.cpp" line="27"/>
         <location filename="../src/settings/settings_translation.cpp" line="64"/>
         <source>Terminal</source>
@@ -557,43 +563,43 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="68"/>
         <source>Custom commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="70"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="72"/>
         <source>Remote management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="76"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="78"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="80"/>
         <source>Default size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="82"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
@@ -604,7 +610,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="86"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
@@ -620,13 +626,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="92"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="94"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
@@ -642,61 +648,61 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="104"/>
         <source>Horizontal split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="106"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="108"/>
         <source>Next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="110"/>
         <source>Previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="112"/>
         <source>Select left workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="114"/>
         <source>Select lower workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="116"/>
         <source>Select right workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="118"/>
         <source>Select upper workspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="120"/>
         <source>Vertical split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="122"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
@@ -707,55 +713,55 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="130"/>
         <source>Go to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="132"/>
         <source>Go to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="134"/>
         <source>Go to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="136"/>
         <source>Go to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="138"/>
         <source>Go to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="140"/>
         <source>Go to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="142"/>
         <source>Go to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="144"/>
         <source>Go to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="146"/>
         <source>Go to tab 9</source>
         <translation type="unfinished"></translation>
@@ -783,7 +789,7 @@
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="152"/>
-        <location filename="../src/main/mainwindow.cpp" line="2100"/>
+        <location filename="../src/main/mainwindow.cpp" line="2122"/>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="716"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
@@ -794,35 +800,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1911"/>
+        <location filename="../src/main/mainwindow.cpp" line="1933"/>
         <source>Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1931"/>
+        <location filename="../src/main/mainwindow.cpp" line="1953"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <source>Select tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/main/mainwindow.cpp" line="2021"/>
+        <location filename="../src/main/mainwindow.cpp" line="2043"/>
         <source>Select file to upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/main/mainwindow.cpp" line="2028"/>
+        <location filename="../src/main/mainwindow.cpp" line="2050"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="146"/>
-        <location filename="../src/main/mainwindow.cpp" line="2094"/>
+        <location filename="../src/main/mainwindow.cpp" line="2116"/>
         <source>Select a directory to save the file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -836,14 +842,12 @@
     <message>
         <location filename="../src/common/utils.cpp" line="202"/>
         <location filename="../src/common/utils.cpp" line="246"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="221"/>
         <source>Close this terminal?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="203"/>
         <location filename="../src/common/utils.cpp" line="247"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="222"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -856,14 +860,12 @@
     <message>
         <location filename="../src/common/utils.cpp" line="214"/>
         <location filename="../src/common/utils.cpp" line="241"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="210"/>
         <source>Close this window?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="215"/>
         <location filename="../src/common/utils.cpp" line="242"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="211"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -927,33 +929,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="280"/>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="295"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="294"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="309"/>
         <source>Un-named Color Scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="466"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="480"/>
         <source>Accessible Color Scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="571"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="576"/>
         <source>Open link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="572"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="577"/>
         <source>Copy link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="574"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="579"/>
         <source>Send email to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="575"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="580"/>
         <source>Copy email address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,12 +963,12 @@
 <context>
     <name>QTermWidget</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="674"/>
+        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="678"/>
         <source>Color Scheme Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="674"/>
+        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="678"/>
         <source>Cannot load color scheme: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -984,7 +986,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="257"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="265"/>
         <source>No servers yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1014,49 +1016,31 @@
     <name>SearchBar</name>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="14"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
         <source>SearchBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="20"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="32"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="42"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
         <source>&lt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="54"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="66"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1264,12 +1248,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="845"/>
+        <location filename="../src/settings/settings.cpp" line="841"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="850"/>
+        <location filename="../src/settings/settings.cpp" line="846"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,55 +1277,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="48"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="50"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="114"/>
         <source>username: %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
         <source>username@: %U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
         <source>remote host: %h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>session number: %#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="115"/>
         <source>title set by shell: %w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
         <source>program name: %n</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
         <source>current directory (short): %d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>current directory (long): %D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="114"/>
         <source>local host: %h</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1349,95 +1333,95 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="544"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="560"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="569"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="560"/>
+        <location filename="../src/views/termwidget.cpp" line="573"/>
         <source>Open in file manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="569"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="578"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>Horizontal split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="572"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="580"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>Vertical split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="582"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="591"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>New tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="589"/>
+        <location filename="../src/views/termwidget.cpp" line="598"/>
         <source>Exit fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="591"/>
+        <location filename="../src/views/termwidget.cpp" line="600"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="594"/>
+        <location filename="../src/views/termwidget.cpp" line="603"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="598"/>
+        <location filename="../src/views/termwidget.cpp" line="607"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="608"/>
+        <location filename="../src/views/termwidget.cpp" line="617"/>
         <source>Encoding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="610"/>
+        <location filename="../src/views/termwidget.cpp" line="619"/>
         <source>Custom commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="612"/>
+        <location filename="../src/views/termwidget.cpp" line="621"/>
         <source>Remote management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="616"/>
+        <location filename="../src/views/termwidget.cpp" line="625"/>
         <source>Upload file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="617"/>
+        <location filename="../src/views/termwidget.cpp" line="626"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="622"/>
+        <location filename="../src/views/termwidget.cpp" line="631"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1297"/>
+        <location filename="../src/views/termwidget.cpp" line="1324"/>
         <source>The debuginfod settings will be effective after restart</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-terminal_zh_CN.ts
+++ b/translations/deepin-terminal_zh_CN.ts
@@ -173,42 +173,42 @@
 <context>
     <name>GroupConfigOptDlg</name>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="38"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="39"/>
         <source>Group Name(Required)</source>
         <translation>组名称（必填）</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="40"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="41"/>
         <source>Add Group</source>
         <translation>添加分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="43"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="44"/>
         <source>Edit Group</source>
         <translation>编辑分组</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="59"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="60"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="61"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="64"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="65"/>
         <source>Please enter a group name</source>
         <translation>请输入分组名称</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="68"/>
+        <location filename="../src/remotemanage/groupconfigoptdlg.cpp" line="69"/>
         <source>The name should be no more than 30 characters</source>
         <translation>名称不能超过30个字符</translation>
     </message>
@@ -216,7 +216,7 @@
 <context>
     <name>Konsole::Session</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Session.cpp" line="763"/>
+        <location filename="../3rdparty/terminalwidget/lib/Session.cpp" line="767"/>
         <source>Press any keys to exit</source>
         <translation>按任意键退出</translation>
     </message>
@@ -224,17 +224,17 @@
 <context>
     <name>Konsole::TerminalDisplay</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1295"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1359"/>
         <source>Size: XXX x XXX</source>
         <translation>大小：XXX x XXX</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1318"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="1382"/>
         <source>Size: %1 x %2</source>
         <translation>大小：%1 x %2</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="3651"/>
+        <location filename="../3rdparty/terminalwidget/lib/TerminalDisplay.cpp" line="3729"/>
         <source>&lt;qt&gt;Output has been &lt;a href=&quot;http://en.wikipedia.org/wiki/Flow_control&quot;&gt;suspended&lt;/a&gt; by pressing Ctrl+S.  Press &lt;b&gt;Ctrl+Q&lt;/b&gt; to resume.&lt;/qt&gt;</source>
         <translation>&lt;qt&gt;输出已被按下 Ctrl+S &lt;a href=&quot;http://en.wikipedia.org/wiki/Flow_control&quot;&gt;暂停&lt;/a&gt;。按 &lt;b&gt;Ctrl+Q&lt;/b&gt; 以恢复。&lt;/qt&gt;</translation>
     </message>
@@ -242,7 +242,7 @@
 <context>
     <name>Konsole::Vt102Emulation</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Vt102Emulation.cpp" line="1116"/>
+        <location filename="../3rdparty/terminalwidget/lib/Vt102Emulation.cpp" line="1278"/>
         <source>No keyboard translator available.  The information needed to convert key presses into characters to send to the terminal is missing.</source>
         <translation>没有可用的键盘转换器。缺少将按键转换为发送到终端字符所需的信息。</translation>
     </message>
@@ -251,29 +251,29 @@
     <name>ListView</name>
     <message>
         <location filename="../src/views/listview.cpp" line="343"/>
-        <location filename="../src/views/listview.cpp" line="1020"/>
+        <location filename="../src/views/listview.cpp" line="1022"/>
         <source>Delete Server</source>
         <translation>删除服务器</translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="343"/>
         <location filename="../src/views/listview.cpp" line="589"/>
-        <location filename="../src/views/listview.cpp" line="1030"/>
+        <location filename="../src/views/listview.cpp" line="1034"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>您确定要删除 %1 吗？</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1022"/>
+        <location filename="../src/views/listview.cpp" line="1024"/>
         <source>Delete Custom Command</source>
         <translation>删除自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1025"/>
+        <location filename="../src/views/listview.cpp" line="1027"/>
         <source>Cancel Server Group</source>
         <translation>取消服务器组</translation>
     </message>
     <message>
-        <location filename="../src/views/listview.cpp" line="1032"/>
+        <location filename="../src/views/listview.cpp" line="1036"/>
         <source>Ungrouped servers will go back to server list!</source>
         <translation>取消分组的服务器将返回到服务器列表！</translation>
     </message>
@@ -281,35 +281,35 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="300"/>
-        <location filename="../src/main/mainwindow.cpp" line="368"/>
+        <location filename="../src/main/mainwindow.cpp" line="334"/>
+        <location filename="../src/main/mainwindow.cpp" line="402"/>
         <source>New window</source>
         <translation>新建窗口</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="389"/>
+        <location filename="../src/main/mainwindow.cpp" line="423"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="897"/>
+        <location filename="../src/main/mainwindow.cpp" line="931"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="899"/>
+        <location filename="../src/main/mainwindow.cpp" line="933"/>
         <source>Close</source>
         <comment>button</comment>
         <translation>关 闭</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2077"/>
+        <location filename="../src/main/mainwindow.cpp" line="2099"/>
         <source>Type path to download file</source>
         <translation>请输入下载文件的路径</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="2403"/>
+        <location filename="../src/main/mainwindow.cpp" line="2491"/>
         <source>Custom Theme</source>
         <translation>自定义主题</translation>
     </message>
@@ -320,89 +320,89 @@
         <location filename="../src/common/utils.cpp" line="291"/>
         <location filename="../src/views/listview.cpp" line="349"/>
         <location filename="../src/views/listview.cpp" line="590"/>
-        <location filename="../src/views/listview.cpp" line="1043"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="286"/>
+        <location filename="../src/views/listview.cpp" line="1047"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="341"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="350"/>
-        <location filename="../src/views/listview.cpp" line="1044"/>
+        <location filename="../src/views/listview.cpp" line="1048"/>
         <source>Delete</source>
         <comment>button</comment>
         <translation>删 除</translation>
     </message>
     <message>
         <location filename="../src/views/listview.cpp" line="591"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="291"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="346"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="102"/>
-        <location filename="../src/views/termwidget.cpp" line="575"/>
+        <location filename="../src/views/termwidget.cpp" line="584"/>
         <source>Close workspace</source>
         <translation>关闭工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="98"/>
-        <location filename="../src/views/termwidget.cpp" line="578"/>
+        <location filename="../src/views/termwidget.cpp" line="587"/>
         <source>Close other workspaces</source>
         <translation>关闭其他工作区</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1349"/>
+        <location filename="../src/views/termwidget.cpp" line="1376"/>
         <source>Could not find &quot;%1&quot;, starting &quot;%2&quot; instead. Please check your shell profile.</source>
         <translation>找不到 “%1”，已启动“%2”代替。请检查Shell配置。</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1357"/>
+        <location filename="../src/views/termwidget.cpp" line="1384"/>
         <source>Could not open &quot;%1&quot;, unable to run it</source>
         <translation>打不开“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1360"/>
+        <location filename="../src/views/termwidget.cpp" line="1387"/>
         <source>Could not find &quot;%1&quot;, unable to run it</source>
         <translation>找不到“%1”，无法正常使用</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1402"/>
+        <location filename="../src/views/termwidget.cpp" line="1513"/>
         <source>Output has been suspended by pressing Ctrl+S. Pressing Ctrl+Q to resume.</source>
         <translation>已经按下Ctrl+S，输出被挂起。可以按下Ctrl+Q继续。</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="126"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="145"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="147"/>
         <source>Tab title format</source>
         <translation>标签标题格式</translation>
     </message>
     <message>
         <location filename="../src/settings/settings_translation.cpp" line="128"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="148"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="150"/>
         <source>Remote tab title format</source>
         <translation>远程标签标题格式</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="74"/>
-        <location filename="../src/views/tabbar.cpp" line="611"/>
-        <location filename="../src/views/tabrenamedlg.cpp" line="246"/>
+        <location filename="../src/views/tabbar.cpp" line="656"/>
+        <location filename="../src/views/tabrenamedlg.cpp" line="301"/>
         <source>Rename title</source>
         <translation>重命名标题</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
-        <location filename="../src/views/tabbar.cpp" line="605"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
+        <location filename="../src/views/tabbar.cpp" line="650"/>
         <source>Close tab</source>
         <translation>关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
-        <location filename="../src/views/tabbar.cpp" line="608"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
+        <location filename="../src/views/tabbar.cpp" line="653"/>
         <source>Close other tabs</source>
         <translation>关闭其他标签页</translation>
     </message>
@@ -539,13 +539,19 @@
         <translation>提供调试信息资源的HTTP文件服务器</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1915"/>
+        <location filename="../src/settings/settings_translation.cpp" line="164"/>
+        <source>Allow OSC52 clipboard access</source>
+        <translation>允许OSC52剪贴板访问</translation>
+    </message>
+    <message>
+        <location filename="../src/main/mainwindow.cpp" line="1937"/>
         <location filename="../src/settings/settings_translation.cpp" line="62"/>
         <source>Others</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1913"/>
+        <location filename="../src/main/mainwindow.cpp" line="1935"/>
+        <location filename="../src/main/mainwindow.cpp" line="2911"/>
         <location filename="../src/main/terminalapplication.cpp" line="27"/>
         <location filename="../src/settings/settings_translation.cpp" line="64"/>
         <source>Terminal</source>
@@ -557,43 +563,43 @@
         <translation>工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="68"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="70"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="72"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1979"/>
+        <location filename="../src/main/mainwindow.cpp" line="2001"/>
         <location filename="../src/settings/settings_translation.cpp" line="76"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="78"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="80"/>
         <source>Default size</source>
         <translation>默认大小</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="82"/>
         <source>Paste</source>
         <translation>粘贴</translation>
@@ -604,7 +610,7 @@
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="86"/>
         <source>Select all</source>
         <translation>全选</translation>
@@ -620,13 +626,13 @@
         <translation>跳转到上一个命令</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="92"/>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="94"/>
         <source>Zoom out</source>
         <translation>缩小</translation>
@@ -642,61 +648,61 @@
         <translation>关闭窗口</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="104"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="106"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="108"/>
         <source>Next tab</source>
         <translation>下一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1959"/>
+        <location filename="../src/main/mainwindow.cpp" line="1981"/>
         <location filename="../src/settings/settings_translation.cpp" line="110"/>
         <source>Previous tab</source>
         <translation>上一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="112"/>
         <source>Select left workspace</source>
         <translation>选择左边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="114"/>
         <source>Select lower workspace</source>
         <translation>选择下面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1961"/>
+        <location filename="../src/main/mainwindow.cpp" line="1983"/>
         <location filename="../src/settings/settings_translation.cpp" line="116"/>
         <source>Select right workspace</source>
         <translation>选择右边的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="118"/>
         <source>Select upper workspace</source>
         <translation>选择上面的工作区</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <location filename="../src/settings/settings_translation.cpp" line="120"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1944"/>
+        <location filename="../src/main/mainwindow.cpp" line="1966"/>
         <location filename="../src/settings/settings_translation.cpp" line="122"/>
         <source>Find</source>
         <translation>查找</translation>
@@ -707,55 +713,55 @@
         <translation>标签标题</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="130"/>
         <source>Go to tab 1</source>
         <translation>切换到标签 1</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="132"/>
         <source>Go to tab 2</source>
         <translation>切换到标签 2</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1962"/>
+        <location filename="../src/main/mainwindow.cpp" line="1984"/>
         <location filename="../src/settings/settings_translation.cpp" line="134"/>
         <source>Go to tab 3</source>
         <translation>切换到标签 3</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="136"/>
         <source>Go to tab 4</source>
         <translation>切换到标签 4</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="138"/>
         <source>Go to tab 5</source>
         <translation>切换到标签 5</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1963"/>
+        <location filename="../src/main/mainwindow.cpp" line="1985"/>
         <location filename="../src/settings/settings_translation.cpp" line="140"/>
         <source>Go to tab 6</source>
         <translation>切换到标签 6</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="142"/>
         <source>Go to tab 7</source>
         <translation>切换到标签 7</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="144"/>
         <source>Go to tab 8</source>
         <translation>切换到标签 8</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1964"/>
+        <location filename="../src/main/mainwindow.cpp" line="1986"/>
         <location filename="../src/settings/settings_translation.cpp" line="146"/>
         <source>Go to tab 9</source>
         <translation>切换到标签 9</translation>
@@ -783,7 +789,7 @@
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="152"/>
-        <location filename="../src/main/mainwindow.cpp" line="2100"/>
+        <location filename="../src/main/mainwindow.cpp" line="2122"/>
         <location filename="../src/remotemanage/serverconfigoptdlg.cpp" line="716"/>
         <source>Select</source>
         <translation>选择</translation>
@@ -794,35 +800,35 @@
         <translation>终端是一款集工作区、多窗口、远程管理、雷神模式等功能的高级终端模拟器。</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1911"/>
+        <location filename="../src/main/mainwindow.cpp" line="1933"/>
         <source>Tabs</source>
         <translation>标签页</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1931"/>
+        <location filename="../src/main/mainwindow.cpp" line="1953"/>
         <source>Switch focus to &quot;+&quot; icon</source>
         <translation>光标焦点切换至“+”图标</translation>
     </message>
     <message>
-        <location filename="../src/main/mainwindow.cpp" line="1960"/>
+        <location filename="../src/main/mainwindow.cpp" line="1982"/>
         <source>Select tab</source>
         <translation>选择标签页</translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="171"/>
-        <location filename="../src/main/mainwindow.cpp" line="2021"/>
+        <location filename="../src/main/mainwindow.cpp" line="2043"/>
         <source>Select file to upload</source>
         <translation>选择要上传的文件</translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="176"/>
-        <location filename="../src/main/mainwindow.cpp" line="2028"/>
+        <location filename="../src/main/mainwindow.cpp" line="2050"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="146"/>
-        <location filename="../src/main/mainwindow.cpp" line="2094"/>
+        <location filename="../src/main/mainwindow.cpp" line="2116"/>
         <source>Select a directory to save the file</source>
         <translation>选择下载文件的保存目录</translation>
     </message>
@@ -836,14 +842,12 @@
     <message>
         <location filename="../src/common/utils.cpp" line="202"/>
         <location filename="../src/common/utils.cpp" line="246"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="221"/>
         <source>Close this terminal?</source>
         <translation>关闭此终端？</translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="203"/>
         <location filename="../src/common/utils.cpp" line="247"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="222"/>
         <source>There is still a process running in this terminal. Closing the terminal will kill it.</source>
         <translation>该终端中仍然有1个进程在运行，关闭终端将杀死进程。</translation>
     </message>
@@ -856,14 +860,12 @@
     <message>
         <location filename="../src/common/utils.cpp" line="214"/>
         <location filename="../src/common/utils.cpp" line="241"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="210"/>
         <source>Close this window?</source>
         <translation>关闭这个窗口？</translation>
     </message>
     <message>
         <location filename="../src/common/utils.cpp" line="215"/>
         <location filename="../src/common/utils.cpp" line="242"/>
-        <location filename="../tests/src/common/ut_utils_test.cpp" line="211"/>
         <source>There are still processes running in this window. Closing the window will kill all of them.</source>
         <translation>窗口内一些终端仍然有进程在运行，关闭窗口会杀死所有进程。</translation>
     </message>
@@ -927,33 +929,33 @@
         <translation>设置终端显示命令或脚本执行后的结果</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="280"/>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="295"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="294"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="309"/>
         <source>Un-named Color Scheme</source>
         <translation>未命名配色方案</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="466"/>
+        <location filename="../3rdparty/terminalwidget/lib/ColorScheme.cpp" line="480"/>
         <source>Accessible Color Scheme</source>
         <translation>无障碍配色方案</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="571"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="576"/>
         <source>Open link</source>
         <translation>打开链接</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="572"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="577"/>
         <source>Copy link</source>
         <translation>复制链接</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="574"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="579"/>
         <source>Send email to...</source>
         <translation>发送邮件到...</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="575"/>
+        <location filename="../3rdparty/terminalwidget/lib/Filter.cpp" line="580"/>
         <source>Copy email address</source>
         <translation>复制邮箱地址</translation>
     </message>
@@ -961,12 +963,12 @@
 <context>
     <name>QTermWidget</name>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="674"/>
+        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="678"/>
         <source>Color Scheme Error</source>
         <translation>配色方案错误</translation>
     </message>
     <message>
-        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="674"/>
+        <location filename="../3rdparty/terminalwidget/lib/qtermwidget.cpp" line="678"/>
         <source>Cannot load color scheme: %1</source>
         <translation>无法加载配色方案：%1</translation>
     </message>
@@ -984,7 +986,7 @@
         <translation>添加服务器</translation>
     </message>
     <message>
-        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="257"/>
+        <location filename="../src/remotemanage/remotemanagementpanel.cpp" line="265"/>
         <source>No servers yet</source>
         <translation>未添加服务器</translation>
     </message>
@@ -1014,49 +1016,31 @@
     <name>SearchBar</name>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="14"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="106"/>
         <source>SearchBar</source>
         <translation>搜索栏</translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="20"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="107"/>
         <source>X</source>
         <translation>关闭</translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="32"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="108"/>
         <source>Find:</source>
         <translation>查找：</translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="42"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="109"/>
         <source>&lt;</source>
         <translation>上一个</translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="54"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="110"/>
         <source>&gt;</source>
         <translation>下一个</translation>
     </message>
     <message>
         <location filename="../3rdparty/terminalwidget/lib/SearchBar.ui" line="66"/>
-        <location filename="../build/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
-        <location filename="../build/Desktop-Debug/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
-        <location filename="../obj-x86_64-linux-gnu/3rdparty/terminalwidget/ui_SearchBar.h" line="111"/>
         <source>...</source>
         <translation>更多</translation>
     </message>
@@ -1264,12 +1248,12 @@
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="845"/>
+        <location filename="../src/settings/settings.cpp" line="841"/>
         <source>Fast</source>
         <translation>快速</translation>
     </message>
     <message>
-        <location filename="../src/settings/settings.cpp" line="850"/>
+        <location filename="../src/settings/settings.cpp" line="846"/>
         <source>Slow</source>
         <translation>慢速</translation>
     </message>
@@ -1293,55 +1277,55 @@
 <context>
     <name>TabRenameWidget</name>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="48"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="50"/>
         <source>Insert</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="114"/>
         <source>username: %u</source>
         <translation>用户名：%u</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
         <source>username@: %U</source>
         <translation>用户名@：%U</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="93"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="95"/>
         <source>remote host: %h</source>
         <translation>远程主机：%h</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>session number: %#</source>
         <translation>会话编号：%#</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="94"/>
-        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="96"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="115"/>
         <source>title set by shell: %w</source>
         <translation>shell设定的窗口标题：%w</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
         <source>program name: %n</source>
         <translation>程序名：%n</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="110"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
         <source>current directory (short): %d</source>
         <translation>当前目录（短）：%d</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="111"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="113"/>
         <source>current directory (long): %D</source>
         <translation>当前目录（长）：%D</translation>
     </message>
     <message>
-        <location filename="../src/views/tabrenamewidget.cpp" line="112"/>
+        <location filename="../src/views/tabrenamewidget.cpp" line="114"/>
         <source>local host: %h</source>
         <translation>本地主机：%h</translation>
     </message>
@@ -1349,95 +1333,95 @@
 <context>
     <name>TermWidget</name>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="544"/>
+        <location filename="../src/views/termwidget.cpp" line="557"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="547"/>
+        <location filename="../src/views/termwidget.cpp" line="560"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="556"/>
+        <location filename="../src/views/termwidget.cpp" line="569"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="560"/>
+        <location filename="../src/views/termwidget.cpp" line="573"/>
         <source>Open in file manager</source>
         <translation>在文件管理器中打开</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="569"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="578"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>Horizontal split</source>
         <translation>横向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="572"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="580"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>Vertical split</source>
         <translation>纵向分屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="582"/>
-        <location filename="../src/views/termwidget.cpp" line="628"/>
+        <location filename="../src/views/termwidget.cpp" line="591"/>
+        <location filename="../src/views/termwidget.cpp" line="637"/>
         <source>New tab</source>
         <translation>新建标签页</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="589"/>
+        <location filename="../src/views/termwidget.cpp" line="598"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="591"/>
+        <location filename="../src/views/termwidget.cpp" line="600"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="594"/>
+        <location filename="../src/views/termwidget.cpp" line="603"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="598"/>
+        <location filename="../src/views/termwidget.cpp" line="607"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="608"/>
+        <location filename="../src/views/termwidget.cpp" line="617"/>
         <source>Encoding</source>
         <translation>编码</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="610"/>
+        <location filename="../src/views/termwidget.cpp" line="619"/>
         <source>Custom commands</source>
         <translation>自定义命令</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="612"/>
+        <location filename="../src/views/termwidget.cpp" line="621"/>
         <source>Remote management</source>
         <translation>远程管理</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="616"/>
+        <location filename="../src/views/termwidget.cpp" line="625"/>
         <source>Upload file</source>
         <translation>上传文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="617"/>
+        <location filename="../src/views/termwidget.cpp" line="626"/>
         <source>Download file</source>
         <translation>下载文件</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="622"/>
+        <location filename="../src/views/termwidget.cpp" line="631"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/views/termwidget.cpp" line="1297"/>
+        <location filename="../src/views/termwidget.cpp" line="1324"/>
         <source>The debuginfod settings will be effective after restart</source>
         <translation>debuginfod 设置将在重启后生效</translation>
     </message>


### PR DESCRIPTION
Feature Description:
Implement OSC52 (Operating System Command 52) protocol to support remote
servers/containers accessing local clipboard through terminal escape sequences,
enabling cross-system clipboard sharing.

Technical Implementation:
1. Parse OSC52 escape sequences (\033]52;<target>;<base64>\a)
2. Unified OSC sequence handling (Xte, OSC52 start, normal OSC)
3. Large data chunking mechanism (>256 bytes auto-chunking)
4. Base64 encoding/decoding + UTF-8 conversion
5. Clipboard target selection (c=CLIPBOARD, p=PRIMARY, s=SECONDARY, 0=ALL)

Core Changes:
- Vt102Emulation: OSC52 sequence parsing, chunking, data accumulation
- termwidget: Clipboard writing, security validation, user settings check
- Add state flags: _osc52InProgress, _osc52IsFirstChunk
- Add allowOSC52 configuration (enabled by default)

Security Limits:
- Max data size: 64MB (after Base64 encoding)
- Configurable via settings (allowOSC52)
- Auto-reject invalid Base64/UTF-8 data

Testing:
- Small data transfer (single chunk, <150 bytes) ✓
- Large data transfer (multi-chunk, 10KB data) ✓
- Clipboard content integrity ✓
- Terminal responsiveness, no lag ✓

Configuration:
- settings.json: "allowOSC52": true