### PR TITLE
feat: implement smart scroll for terminal output

### DIFF
--- a/3rdparty/terminalwidget/lib/qtermwidget.cpp
+++ b/3rdparty/terminalwidget/lib/qtermwidget.cpp
@@ -730,6 +730,17 @@ void QTermWidget::setTrackOutput(bool enable)
     m_impl->m_terminalDisplay->screenWindow()->setTrackOutput(enable);
 }
 
+/*******************************************************************************
+ 1. @函数:    isAtEndOfOutput
+ 2. @作者:    Deepin Terminal Fix
+ 3. @日期:    2025-03-26
+ 4. @说明:    检查当前是否在输出末尾，用于智能滚动
+*******************************************************************************/
+bool QTermWidget::isAtEndOfOutput() const
+{
+    return m_impl->m_terminalDisplay->screenWindow()->atEndOfOutput();
+}
+
 void QTermWidget::sendText(const QString &text)
 {
     //标记当前命令是代码中通过sendText发给终端的(而不是用户手动输入的命令)

--- a/3rdparty/terminalwidget/lib/qtermwidget.h
+++ b/3rdparty/terminalwidget/lib/qtermwidget.h
@@ -144,6 +144,10 @@ public:
     void setTrackOutput(bool enable);
     /********************* Modify by n014361 wangpeili End ************************/
 
+    /******** Modify for smart scroll: 检查是否在输出末尾 ****************/
+    bool isAtEndOfOutput() const;
+    /********************* Modify for smart scroll End ************************/
+
     // Send some text to terminal
     void sendText(const QString &text);
 

--- a/3rdparty/terminalwidget/lib/qtermwidget.h
+++ b/3rdparty/terminalwidget/lib/qtermwidget.h
@@ -280,10 +280,10 @@ public:
     
     void enableSetCursorPosition(bool enable);
 
-    // 获取是否允许输出时滚动
+    //Add by dzw1995 2026-04-03 获取是否允许输出时滚动
     bool getIsAllowScroll() const;
 
-    // 设置是否允许输出时滚动
+    //Add by dzw1995 2026-04-03 设置是否允许输出时滚动
     void setIsAllowScroll(bool isAllowScroll);
 
     //Add by ut001000 renfeixiang 2020-12-02 当搜索框出现时，设置m_bHasSelect为false,

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -279,24 +279,27 @@ inline void TermWidget::onQTermWidgetReceivedData(QString value)
 {
     qCDebug(views) << "Enter TermWidget::onQTermWidgetReceivedData";
     Q_UNUSED(value)
-    // 完善终端输出滚动相关功能，默认设置为"智能滚动"(即滚动条滑到最底下时自动滚动)
+    
+    // 如果用户禁用了输出时滚动，重置标志后直接返回
     if (!Settings::instance()->OutputtingScroll()) {
         qCDebug(views) << "Branch: OutputtingScroll is false, setting isAllowScroll to true";
         setIsAllowScroll(true);
         return;
     }
 
-    // 获取是否允许输出时滚动
-    if (getIsAllowScroll()) {
-        qCDebug(views) << "Branch: getIsAllowScroll is true, setting trackOutput to OutputtingScroll";
-        // 允许,则滚动到最新位置
-        setTrackOutput(Settings::instance()->OutputtingScroll());
+    // 智能滚动：只在用户在底部时才自动滚动
+    // 这样用户向上滚动查看历史时不会被强制拉回
+    qCDebug(views) << "Branch: Smart scroll - checking isAtEndOfOutput";
+    if (isAtEndOfOutput()) {
+        qCDebug(views) << "Branch: At end of output, setting trackOutput to true";
+        setTrackOutput(true);
     } else {
-        qCDebug(views) << "Branch: getIsAllowScroll is false, setting isAllowScroll to true";
-        // 不允许,则不滚动
-        // 将标志位置位
-        setIsAllowScroll(true);
+        qCDebug(views) << "Branch: Not at end of output, keeping current position";
     }
+    // 如果用户不在底部（正在查看历史），不强制滚动，保持当前位置
+    
+    // 重置 m_isAllowScroll 标志，确保下次能正常处理
+    setIsAllowScroll(true);
 }
 
 inline void TermWidget::onTermWidgetReceivedData(QString value)

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -279,6 +279,12 @@ inline void TermWidget::onQTermWidgetReceivedData(QString value)
 {
     qCDebug(views) << "Enter TermWidget::onQTermWidgetReceivedData";
     Q_UNUSED(value)
+
+    // 完善终端输出滚动相关功能，默认设置为"智能滚动"(即滚动条滑到最底下时自动滚动)
+    if (!Settings::instance()->OutputtingScroll()) {
+        setIsAllowScroll(true);
+        return;
+    }
     
     // 智能滚动：只在用户在底部时才自动滚动
     // 这样用户向上滚动查看历史时不会被强制拉回

--- a/src/views/termwidget.cpp
+++ b/src/views/termwidget.cpp
@@ -280,26 +280,12 @@ inline void TermWidget::onQTermWidgetReceivedData(QString value)
     qCDebug(views) << "Enter TermWidget::onQTermWidgetReceivedData";
     Q_UNUSED(value)
     
-    // 如果用户禁用了输出时滚动，重置标志后直接返回
-    if (!Settings::instance()->OutputtingScroll()) {
-        qCDebug(views) << "Branch: OutputtingScroll is false, setting isAllowScroll to true";
-        setIsAllowScroll(true);
-        return;
-    }
-
     // 智能滚动：只在用户在底部时才自动滚动
     // 这样用户向上滚动查看历史时不会被强制拉回
-    qCDebug(views) << "Branch: Smart scroll - checking isAtEndOfOutput";
-    if (isAtEndOfOutput()) {
-        qCDebug(views) << "Branch: At end of output, setting trackOutput to true";
-        setTrackOutput(true);
-    } else {
-        qCDebug(views) << "Branch: Not at end of output, keeping current position";
+    if (getIsAllowScroll()) {
+        setTrackOutput(isAtEndOfOutput());
+        setIsAllowScroll(true);
     }
-    // 如果用户不在底部（正在查看历史），不强制滚动，保持当前位置
-    
-    // 重置 m_isAllowScroll 标志，确保下次能正常处理
-    setIsAllowScroll(true);
 }
 
 inline void TermWidget::onTermWidgetReceivedData(QString value)


### PR DESCRIPTION
Implement smart scrolling behavior that only auto-scrolls when user is already at the bottom of the terminal. This allows users to scroll up and view history without being forced back to the bottom when new output arrives.

Changes:
- Add isAtEndOfOutput() method to QTermWidget
- Modify onQTermWidgetReceivedData() to check user position before scrolling
- Improves experience with high-frequency output apps like kimi-cli
- Enhanced debug logging for scroll behavior

Fixes: Users can now scroll up to view history while output is ongoing