### PR TITLE
fix(search-bar): adjust search icon size to fix oversized display

### DIFF
--- a/src/views/pagesearchbar.cpp
+++ b/src/views/pagesearchbar.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -283,7 +283,7 @@ void PageSearchBar::updateSizeMode()
 
         if (searchIconBtn) {
             qCDebug(views) << "Branch: searchIconBtn exists, setting normal icon size";
-            searchIconBtn->setIconSize(QSize(ICON_CTX_SIZE_32, ICON_CTX_SIZE_32));
+            searchIconBtn->setIconSize(QSize(ICON_CTX_SIZE_24, ICON_CTX_SIZE_24));
         }
     }
 


### PR DESCRIPTION
Reduce search icon size from 32x32 to 24x24 pixels for better visual proportion with search bar height.

将搜索图标大小从32x32像素调整为24x24像素，优化视觉比例。

Log: 调整搜索框图标大小
PMS: BUG-354687
Influence: 修复后搜索图标大小适中，与搜索框高度比例协调，提升视觉效果。