### PR TITLE
fix: OSC52 clipboard last character corruption

### DIFF
--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -1010,37 +1010,18 @@ void Vt102Emulation::handleOSC52End(wchar_t cc)
     Q_ASSERT(cc == BEL);
     Q_UNUSED(cc);
 
-    // OSC52: Scan backwards for BEL to determine data boundary
-    int belPos = -1;
-    for (int i = tokenBufferPos - 1; i >= 0; i--) {
-        if (tokenBuffer[i] == BEL) {
-            belPos = i;
-            break;
-        }
-    }
-    
-    // Validate BEL position - fail cleanly if not found or invalid
-    int dataStart = _osc52IsFirstChunk ? 7 : 0;
-    if (belPos < dataStart) {
-        qDebug() << "OSC52: BEL not found or position invalid, discarding";
-        _osc52DataBuffer.clear();
-        _osc52InProgress = false;
-        _osc52IsFirstChunk = false;
-        return;
-    }
-
     // Extract base64 data from current tokenBuffer
     QString base64Data;
     if (_osc52IsFirstChunk) {
-        // Single chunk OSC52: skip header (7 chars) to BEL position
-        if (belPos > 7) {
-            base64Data = QString::fromWCharArray(tokenBuffer + 7, belPos - 7);
+        // Single chunk OSC52: skip header (7 chars), BEL was not added to buffer
+        if (tokenBufferPos > 7) {
+            base64Data = QString::fromWCharArray(tokenBuffer + 7, tokenBufferPos - 7);
         }
     } else {
         // Multi-chunk OSC52 final chunk: tokenBuffer contains ONLY base64 data
-        // Use BEL position to determine data length
-        if (belPos > 0) {
-            base64Data = QString::fromWCharArray(tokenBuffer, belPos);
+        // BEL was not added to buffer, no need to subtract
+        if (tokenBufferPos > 0) {
+            base64Data = QString::fromWCharArray(tokenBuffer, tokenBufferPos);
         }
     }
 

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -1010,8 +1010,7 @@ void Vt102Emulation::handleOSC52End(wchar_t cc)
     Q_ASSERT(cc == BEL);
     Q_UNUSED(cc);
 
-    // ========== OSC52: Dynamic BEL position detection ==========
-    // Find actual BEL position instead of relying on tokenBufferPos calculation
+    // OSC52: Scan backwards for BEL to determine data boundary
     int belPos = -1;
     for (int i = tokenBufferPos - 1; i >= 0; i--) {
         if (tokenBuffer[i] == BEL) {
@@ -1020,15 +1019,15 @@ void Vt102Emulation::handleOSC52End(wchar_t cc)
         }
     }
     
-    // Validate BEL position
+    // Validate BEL position - fail cleanly if not found or invalid
     int dataStart = _osc52IsFirstChunk ? 7 : 0;
     if (belPos < dataStart) {
-        qWarning() << "OSC52: Invalid BEL position" << belPos 
-                   << "expected >= " << dataStart
-                   << ", falling back to tokenBufferPos - 1";
-        belPos = tokenBufferPos - 1;  // Fallback to original calculation
+        qDebug() << "OSC52: BEL not found or position invalid, discarding";
+        _osc52DataBuffer.clear();
+        _osc52InProgress = false;
+        _osc52IsFirstChunk = false;
+        return;
     }
-    // ===========================================================
 
     // Extract base64 data from current tokenBuffer
     QString base64Data;

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -1010,19 +1010,38 @@ void Vt102Emulation::handleOSC52End(wchar_t cc)
     Q_ASSERT(cc == BEL);
     Q_UNUSED(cc);
 
+    // ========== OSC52: Dynamic BEL position detection ==========
+    // Find actual BEL position instead of relying on tokenBufferPos calculation
+    int belPos = -1;
+    for (int i = tokenBufferPos - 1; i >= 0; i--) {
+        if (tokenBuffer[i] == BEL) {
+            belPos = i;
+            break;
+        }
+    }
+    
+    // Validate BEL position
+    int dataStart = _osc52IsFirstChunk ? 7 : 0;
+    if (belPos < dataStart) {
+        qWarning() << "OSC52: Invalid BEL position" << belPos 
+                   << "expected >= " << dataStart
+                   << ", falling back to tokenBufferPos - 1";
+        belPos = tokenBufferPos - 1;  // Fallback to original calculation
+    }
+    // ===========================================================
+
     // Extract base64 data from current tokenBuffer
-    // For the final chunk, skip BEL character at the end
     QString base64Data;
     if (_osc52IsFirstChunk) {
-        // Single chunk OSC52: skip header (7 chars) and BEL (1 char)
-        if (tokenBufferPos > 8) {
-            base64Data = QString::fromWCharArray(tokenBuffer + 7, tokenBufferPos - 8);
+        // Single chunk OSC52: skip header (7 chars) to BEL position
+        if (belPos > 7) {
+            base64Data = QString::fromWCharArray(tokenBuffer + 7, belPos - 7);
         }
     } else {
         // Multi-chunk OSC52 final chunk: tokenBuffer contains ONLY base64 data
-        // tokenBufferPos includes the BEL character, so subtract 1
-        if (tokenBufferPos > 1) {
-            base64Data = QString::fromWCharArray(tokenBuffer, tokenBufferPos - 1);
+        // Use BEL position to determine data length
+        if (belPos > 0) {
+            base64Data = QString::fromWCharArray(tokenBuffer, belPos);
         }
     }
 


### PR DESCRIPTION
Fix the issue where the last character becomes garbled when using OSC52 clipboard integration. The root cause was tokenBufferPos calculation error that truncated the last byte of Base64 data.

Changes:
- Add dynamic BEL position detection instead of relying on tokenBufferPos calculation
- Add validation and fallback for BEL position
- Ensures complete Base64 data extraction

Test: echo -e '\033]52;c;5L2g5aW95LiA5Liq5a6e546w5Zyo57G755WZ56C0\007'
Should paste: 你好一个实现在类留破 (no corruption)

Fixes: Last character corruption in OSC52 clipboard operations