### PR TITLE
fix(terminal): remove redundant cursor blink-off background clearing

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -750,16 +750,10 @@ void TerminalDisplay::drawCursor(QPainter& painter,
                                  bool& invertCharacterColor)
 {
     QRectF cursorRect = rect;
-    // 覆盖整行高度，避免底部/顶部 1px 漏刷
     cursorRect.setHeight(_fontHeight);
 
     if (_cursorBlinking)
     {
-       // 隐藏帧：用传入的背景色清除光标所在单元格（水平扩 1px 覆盖描边）
-       painter.save();
-       painter.setPen(Qt::NoPen);
-       painter.fillRect(cursorRect.adjusted(-1, 0, 1, 0), backgroundColor);
-       painter.restore();
        return;
     }
     else
@@ -925,19 +919,7 @@ void TerminalDisplay::drawTextFragment(QPainter& painter ,
         drawBackground(painter,rect,backgroundColor,
                        false /* do not use transparency */);
 
-    // 光标隐藏帧：在绘制光标前先清除当前单元格，避免上一帧轮廓残留
-    if (!_hideCursor && (style->rendition & RE_CURSOR) && _cursorBlinking)
-    {
-        drawBackground(painter, rect, backgroundColor, false /* do not use transparency */);
-    }
-
-    if (!_hideCursor && (style->rendition & RE_CURSOR) && _cursorBlinking)
-    {
-        drawBackground(painter, rect, backgroundColor, false /* do not use transparency */);
-    }
-
     // draw cursor shape if the current character is the cursor
-    // 处于隐藏帧时，先用 cell 背景清除，避免上一帧轮廓残留
     bool invertCharacterColor = false;
 
     if (!_hideCursor)


### PR DESCRIPTION
Remove unnecessary fillRect/drawBackground calls in cursor blink-off path that overwrote transparent background with opaque color.

移除光标隐藏帧中多余的背景清除操作，该操作会用不透明色覆盖
已绘制的透明背景。

Log: 修复光标隐藏帧背景不透明问题
PMS: BUG-356489
Influence: 透明背景下光标闪烁隐藏帧现在正确显示透明效果