### PR TITLE
fix: title bar color error

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2899,6 +2899,10 @@ void MainWindow::themeActionTriggeredSlot(QAction *action)
 void MainWindow::themeActionHoveredSlot(QAction *action)
 {
     qCDebug(mainprocess) << "Enter MainWindow::themeActionHoveredSlot";
+
+    if (Settings::instance()->bSwitchTheme) {
+        return;
+    }
     if (switchThemeMenu->hoveredThemeStr != action->text()) {
         switchThemeMenu->hoveredThemeStr = action->text();
         Settings::instance()->bSwitchTheme = false;


### PR DESCRIPTION
Fix: Flickering when switching themes

Log: `menuHideSetThemeSlot` is called when the menu is hidden. Previously, it always used `currCheckThemeAction` (the old theme) to “restore” the theme. When the user tapped a new theme, hiding the menu would trigger a restore to the old theme, causing flickering.

pms: bug-347863
