### PR TITLE
Fix: Remote servers cannot be effectively grouped.

### DIFF
--- a/src/remotemanage/groupconfigoptdlg.cpp
+++ b/src/remotemanage/groupconfigoptdlg.cpp
@@ -85,6 +85,14 @@ GroupConfigOptDlg::GroupConfigOptDlg(const QString &groupName, QWidget *parent)
             ServerConfigManager::instance()->delServerConfig(config);
             ServerConfigManager::instance()->saveServerConfig(newConfig);
         }
+
+        // 修复BUG 355415: 确保即使没有选中任何服务器，分组也会被添加到配置中
+        QString groupName = m_groupNameEdit->text().trimmed();
+        QMap<QString, QList<ServerConfig *>> &serverConfigs = ServerConfigManager::instance()->getServerConfigs();
+        if (!serverConfigs.contains(groupName)) {
+            serverConfigs[groupName] = QList<ServerConfig *>();
+        }
+
         accept();
     });
     connect(pCancelButton, &DPushButton::clicked, this, [this] {


### PR DESCRIPTION
Log: When adding a group, only when servers are selected will a group record be created. If no servers are selected, the code block is not executed, causing the group to not be added to m_serverConfigs.

PMS: bug-357213