### PR TITLE
chore: add quotes to rm command in postrm script

### DIFF
--- a/debian/deepin-terminal.postrm
+++ b/debian/deepin-terminal.postrm
@@ -4,8 +4,8 @@
 #DEBHELPER#
 
 userName=$(who)
-if [ $1 = "purge" ]; then 
-	rm -rf /home/${userName%% *}/.config/deepin/deepin-terminal/*
+if [ "$1" = "purge" ]; then
+	rm -rf "/home/${userName%% *}/.config/deepin/deepin-terminal/"*
 
 	#解决安装终端后/nonexistent目录下会残留install_flag配置文件的问题
 	if [ -f /nonexistent/.config/deepin/deepin-terminal/install_flag ]


### PR DESCRIPTION
Quote variables in rm -rf command to prevent globbing and word splitting, addressing shellcheck SC2086 warning for safer package removal.

log: add quotes to rm command in postrm script