### PR TITLE
fix(remotemanage): group dialog obscured by terminal window

### DIFF
--- a/src/remotemanage/remotemanagementpanel.cpp
+++ b/src/remotemanage/remotemanagementpanel.cpp
@@ -209,7 +209,7 @@ void RemoteManagementPanel::showAddGroupConfigDlg(const QString &groupName)
     // 弹窗显示
     Service::instance()->setIsDialogShow(window(), true);
 
-    GroupConfigOptDlg *dlg = new GroupConfigOptDlg(groupName);
+    GroupConfigOptDlg *dlg = new GroupConfigOptDlg(groupName, this);
     connect(dlg, &ServerConfigOptDlg::finished, this, [ = ](int result) {
         // 弹窗隐藏或消失
         Service::instance()->setIsDialogShow(window(), false);


### PR DESCRIPTION
GroupConfigOptDlg was created without parent and window modality, causing it to be hidden behind terminal. Now passes parent and sets Qt::WindowModal, matching ServerConfigOptDlg behavior.

添加分组对话框未设置父窗口和窗口模态，导致被终端窗口遮挡。
现在传入父窗口并设置Qt::WindowModal，与添加服务器对话框一致。

Log: 修复添加分组对话框被终端窗口遮挡的问题
PMS: BUG-358805
Influence: 修复后添加分组对话框始终保持在终端窗口之上，不会被遮挡。