### PR TITLE
fix: ignore CSI < and CSI = private parameter sequences

### DIFF
--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -266,7 +266,7 @@ void Vt102Emulation::initTokenizer()
 #define les(P,L,C) (p == (P) && s[L] < 256 && (charClass[s[(L)]] & (C)) == (C))
 #define eec(C)     (p >=  3  && cc == (C))
 #define ees(C)     (p >=  3  && cc < 256 && (charClass[cc] & (C)) == (C))
-#define eps(C)     (p >=  3  && s[2] != '?' && s[2] != '!' && s[2] != '>' && cc < 256 && (charClass[cc] & (C)) == (C))
+#define eps(C)     (p >=  3  && s[2] != '?' && s[2] != '!' && s[2] != '>' && s[2] != '<' && s[2] != '=' && cc < 256 && (charClass[cc] & (C)) == (C))
 #define epp( )     (p >=  3  && s[2] == '?')
 #define epe( )     (p >=  3  && s[2] == '!')
 #define egt( )     (p >=  3  && s[2] == '>')
@@ -322,6 +322,8 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(3,2,'?')) { return; }
     if (lec(3,2,'>')) { return; }
     if (lec(3,2,'!')) { return; }
+    if (lec(3,2,'<')) { return; }
+    if (lec(3,2,'=')) { return; }
     if (lun(       )) { processToken( TY_CHR(), applyCharset(cc), 0);   resetTokenizer(); return; }
     if (lec(2,0,ESC)) { processToken( TY_ESC(s[1]), 0, 0);              resetTokenizer(); return; }
     if (les(3,1,SCS)) { processToken( TY_ESC_CS(s[1],s[2]), 0, 0);      resetTokenizer(); return; }
@@ -351,6 +353,8 @@ void Vt102Emulation::receiveChar(wchar_t cc)
             processToken( TY_CSI_PR(cc,argv[i]), 0, 0);
         else if (egt())
             processToken( TY_CSI_PG(cc), 0, 0); // spec. case for ESC]>0c or ESC]>c
+        else if (p >= 3 && (s[2] == '<' || s[2] == '='))
+            ; // silently ignore CSI < and CSI = sequences (e.g. Kitty keyboard pop)
         else if (cc == 'm' && argc - i >= 4 && (argv[i] == 38 || argv[i] == 48) && argv[i+1] == 2)
         {
             // ESC[ ... 48;2;<red>;<green>;<blue> ... m -or- ESC[ ... 38;2;<red>;<green>;<blue> ... m


### PR DESCRIPTION
Silently ignore unrecognized CSI sequences with < and = private parameter prefixes to prevent residual character output.

静默忽略未识别的带 < 和 = 私有参数前缀的 CSI 序列，
防止残留字符输出。

Log: 修复退出Claude Code时终端输出u字符的问题
PMS: BUG-356495
Influence: 修复后支持Kitty键盘协议的CSI <和CSI =序列，退出Claude Code等程序时不再有残留字符输出。