### PR TITLE
fix(views): adaptive width layout for remote management

### DIFF
--- a/src/views/focusframe.cpp
+++ b/src/views/focusframe.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -49,11 +49,8 @@ void FocusFrame::paintEvent(QPaintEvent *event)
         // qCDebug(views) << "Branch: Focus is active";
         // 边框
         QPainterPath FramePath;
-        // 效果和以下代码类似，兼容紧凑模式
-        // 类似: paintRoundedRect(FramePath, QRect(2, 2, 218, 58));
-        // TODO  master 
-        // paintRoundedRect(FramePath, rect().adjusted(2, 2, 0, 0));
-        paintRoundedRect(FramePath, QRect(2, 2, m_isWideFrame ? 358 : 218, 58));
+        // 使用动态宽度绘制边框
+        paintRoundedRect(FramePath, QRect(2, 2, qMax(0, rect().width() - 4), qMax(0, rect().height() - 4)));
         // 获取活动色
         QPen pen(pa.color(DPalette::Highlight), 2);
         painter.setPen(pen);
@@ -62,10 +59,8 @@ void FocusFrame::paintEvent(QPaintEvent *event)
 
         // 绘制背景
         QPainterPath itemBackgroudPath;
-        // 类似: paintRoundedRect(itemBackgroudPath, QRect(4, 4, 214, 54));
-        // TODO  master 
-        // paintRoundedRect(FramePath, rect().adjusted(4, 4, -2, -2));
-        paintRoundedRect(itemBackgroudPath, QRect(4, 4, m_isWideFrame ? 354 : 214, 54));
+        // 使用动态宽度绘制背景
+        paintRoundedRect(itemBackgroudPath, QRect(4, 4, qMax(0, rect().width() - 8), qMax(0, rect().height() - 8)));
         // 产品要有悬浮效果的
         // painter.fillPath(itemBackgroudPath, QBrush(pa.color(DPalette::ObviousBackground)));
         // ui要有框，背景不变
@@ -75,10 +70,8 @@ void FocusFrame::paintEvent(QPaintEvent *event)
         // 焦点不在，不绘制
         // 绘制背景
         QPainterPath itemBackgroudPath;
-        // 类似: paintRoundedRect(itemBackgroudPath, QRect(0, 0, 220, 60));
-        // TODO  master 
-        // paintRoundedRect(itemBackgroudPath, rect().adjusted(0, 0, 1, 1));
-        paintRoundedRect(itemBackgroudPath, QRect(0, 0, m_isWideFrame ? 360 : 220, 60));
+        // 使用动态宽度绘制背景
+        paintRoundedRect(itemBackgroudPath, QRect(0, 0, rect().width(), rect().height()));
         // 产品要有悬浮效果的
         // painter.fillPath(itemBackgroudPath, QBrush(pa.color(DPalette::ObviousBackground)));
         // ui要有框，背景不变

--- a/src/views/itemwidget.cpp
+++ b/src/views/itemwidget.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -86,7 +86,7 @@ void ItemWidget::setFuncIcon(ItemFuncType iconType)
 {
     qCDebug(views) << "Enter ItemWidget::setFuncIcon";
     // 统一设置大小
-    m_funcButton->setIconSize(QSize(20, 20));
+    m_funcButton->setIconSize(QSize(16, 16));
     m_deleteButton->setIconSize(QSize(20, 20));
     m_deleteButton->hide();
     switch (iconType) {
@@ -341,16 +341,18 @@ void ItemWidget::updateSizeMode()
 {
     qCDebug(views) << "Enter ItemWidget::updateSizeMode";
 #ifdef DTKWIDGET_CLASS_DSizeMode
+    // 设置最小宽度，防止挤压，允许宽度自适应
+    setMinimumWidth(220);
     if (DGuiApplicationHelper::isCompactMode()) {
         qCDebug(views) << "Branch: compact mode";
         m_iconLayout->setContentsMargins(s_ItemIconContentMarginsCompact);
-        setFixedSize(220, s_ItemHeightCompact);
+        setFixedHeight(s_ItemHeightCompact);
         setFont(m_firstline, DFontSizeManager::T6, ItemTextColor_Text);
         setFont(m_secondline, DFontSizeManager::T7, ItemTextColor_TextTips);
     } else {
         qCDebug(views) << "Branch: normal mode";
         m_iconLayout->setContentsMargins(s_ItemIconContentMargins);
-        setFixedSize(220, s_ItemHeight);
+        setFixedHeight(s_ItemHeight);
         setFont(m_firstline, DFontSizeManager::T7, ItemTextColor_Text);
         setFont(m_secondline, DFontSizeManager::T8, ItemTextColor_TextTips);
     }
@@ -362,14 +364,9 @@ void ItemWidget::initUI()
 {
     if (m_functType != ItemFuncType_GroupLabel && m_functType != ItemFuncType_ItemLabel)
     {
-        // 初始化控件大小
-        if (m_functType == ItemFuncType_UngroupedItem) {
-            setGeometry(0, 0, 360, 60);
-            setFixedSize(360, 60);
-        } else {
-            setGeometry(0, 0, 220, 60);
-            setFixedSize(220, 60);
-        }
+        // 设置最小宽度，防止挤压，允许宽度自适应
+        setMinimumWidth(220);
+        setFixedHeight(60);
     }
     else
     {
@@ -396,12 +393,13 @@ void ItemWidget::initUI()
     setFont(m_secondline, DFontSizeManager::T8, ItemTextColor_TextTips);
     m_firstline->setContentsMargins(0, 0, 0, 0);
     m_secondline->setContentsMargins(0, 0, 0, 0);
-    m_firstline->setFixedWidth(138);
-    m_secondline->setFixedWidth(138);
+    m_firstline->setMaximumWidth(138);
+    m_secondline->setMaximumWidth(138);
     m_textLayout->setContentsMargins(0, 0, 0, 0);
     m_textLayout->setSpacing(0);
     m_textLayout->addStretch(13);
     m_textLayout->addWidget(m_firstline, 13);
+    m_textLayout->setAlignment(m_firstline, Qt::AlignLeft);
     m_textLayout->addStretch(9);
     if (m_functType != ItemFuncType_GroupLabel && m_functType != ItemFuncType_ItemLabel)
     {
@@ -418,10 +416,10 @@ void ItemWidget::initUI()
     m_funcButton->setFlat(true);
     m_funcButton->setFocusPolicy(Qt::NoFocus);
     m_funcLayout->addStretch();
-    m_funcLayout->setContentsMargins(5, 0, 5, 0);
+    m_funcLayout->setContentsMargins(5, 0, 10, 0);
     m_funcLayout->addWidget(m_deleteButton);
     m_funcLayout->addWidget(m_funcButton);
-    m_funcLayout->addStretch();
+    m_funcLayout->setSpacing(5);
 
     // 整体布局
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -433,16 +431,15 @@ void ItemWidget::initUI()
             m_checkBox->hide();
         }
         m_mainLayout->addLayout(m_iconLayout);
-        m_mainLayout->addLayout(m_textLayout);
+        m_mainLayout->addLayout(m_textLayout, 1);
         m_mainLayout->addLayout(m_funcLayout);
     } else {
         m_checkBox->hide();
         m_iconButton->hide();
-        m_mainLayout->addLayout(m_textLayout);
+        m_mainLayout->addLayout(m_textLayout, 1);
         m_deleteButton->hide();
         m_funcButton->hide();
     }
-    m_mainLayout->addStretch();
     setLayout(m_mainLayout);
 
     // 根据不同布局初始化界面


### PR DESCRIPTION
Remove hardcoded width values and use dynamic width calculation to support adaptive layout in remote management panel.

移除硬编码宽度值，使用动态宽度计算，支持远程管理面板自适应布局。

Log: 修复远程管理面板布局自适应问题
PMS: BUG-361273
Influence: 修复后界面元素能够根据容器大小自适应宽度，提升不同分辨率下的显示效果。