### PR TITLE
fix(views): use real-time system theme in TermWidget constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ CMakeLists.txt.user
 deepin-terminal.pro.user
 .cache/*
 .cursor/*
+.claude/
+.codegraph/
+.npm-cache/
+.trellis/
+obj-*-linux-gnu/

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
 #if (DTK_VERSION >= DTK_VERSION_CHECK(5,6,8,0))
     //qCDebug(mainprocess) << "current libdtkcore5 > 5.6.8.0";
     DLogManager::registerJournalAppender();
+    DLogManager::registerFileAppender();
     //qCInfo(mainprocess) << "Current log register journal!";
 #ifdef QT_DEBUG
     DLogManager::registerConsoleAppender();

--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -2752,6 +2752,9 @@ void MainWindow::switchThemeAction(QAction *action)
     if (action == autoThemeAction) {
         Settings::instance()->setExtendColorScheme(THEME_NO);
         DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::UnknownType);
+        // Sync colorScheme to actual system theme so new TermWidgets get correct colors
+        QString sysTheme = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) ? THEME_LIGHT : THEME_DARK;
+        Settings::instance()->setColorScheme(sysTheme);
         emit DGuiApplicationHelper::instance()->themeTypeChanged(DGuiApplicationHelper::instance()->themeType());
         return;
     }

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -141,6 +141,14 @@ void Settings::init()
         setColorScheme("Dark");
         setExtendColorScheme("");
         qCDebug(tsettings) << "Color scheme initialized";
+    } else if (DGuiApplicationHelper::instance()->paletteType() == DGuiApplicationHelper::UnknownType
+               && extendColorScheme().isEmpty()) {
+        // 跟随系统模式：colorScheme 可能因上次关闭后系统主题变化而过期，需同步为当前系统主题
+        QString sysTheme = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) ? "Light" : "Dark";
+        if (colorScheme() != sysTheme) {
+            qCDebug(tsettings) << "Syncing colorScheme to system theme:" << colorScheme() << "->" << sysTheme;
+            setColorScheme(sysTheme);
+        }
     }
     /******** Modify by n014361 wangpeili 2020-01-10:   增加窗口状态选项  ************/
     auto windowState = settings->option("advanced.window.use_on_starting");


### PR DESCRIPTION
TermWidget 构造函数中原先依赖 settings 中的 colorScheme 快照值来决定 初始主题，导致在跟随系统模式下新建窗口时，终端内容区可能与系统
当前实际主题不一致（例如系统已切到浅色，但新窗口仍显示深色）。

改为直接通过 DGuiApplicationHelper::instance()->themeType() 获取 系统当前真实主题，确保新建窗口始终与系统保持同步。

其他改动：
- 注册 file appender 以便诊断问题
- .gitignore 补充 IDE/构建产物忽略规则

pms: bug-355415 bug-346497