### PR TITLE
test: migrate unit tests from Qt5 to Qt5/Qt6 compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,6 @@ install(FILES src/assets/config/logconfig/org.deepin.terminal.json
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-log-viewer/deepin-log.conf.d/)
 
 # Unit Test
-# if (CMAKE_BUILD_TYPE MATCHES Debug)
-# add_subdirectory(tests)
-# endif()
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,11 +16,11 @@ set(PROJECT_NAME_TEST ${PROJECT_NAME})
 
 add_compile_options(-fno-access-control)
 
-find_package(Qt5Test REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
 find_package(GTest REQUIRED)
 
-add_definitions(${Qt5Test_DEFINITIONS})
-add_definitions(-D UNIT_TEST)
+# Qt6::Test 通过 target_link_libraries 自动传播定义，无需手动 add_definitions
+add_definitions(-DUNIT_TEST)
 
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories("src/common")
@@ -63,6 +63,7 @@ FILE(GLOB allThirdPartySource
     ../3rdparty/terminalwidget/lib/*.cpp
     ../3rdparty/terminalwidget/lib/history/*.cpp
     ../3rdparty/terminalwidget/lib/history/compact/*.cpp
+    ../3rdparty/terminalwidget/lib/encodes/*.cpp
 )
 
 FILE(GLOB qrcFiles
@@ -91,7 +92,11 @@ FILE(GLOB allTestSource
 )
 
 set(UI ../3rdparty/terminalwidget/lib/SearchBar.ui)
-qt5_wrap_ui(UI_SRCS ${UI})
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt6_wrap_ui(UI_SRCS ${UI})
+else()
+    qt5_wrap_ui(UI_SRCS ${UI})
+endif()
 
 set(KB_LAYOUT_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${TERMINALWIDGET_LIBRARY_NAME}/kb-layouts")
 set(COLORSCHEMES_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${TERMINALWIDGET_LIBRARY_NAME}/color-schemes")
@@ -113,20 +118,21 @@ add_executable(${PROJECT_NAME_TEST}
     ${uiFiles}
 )
 
-target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${Qt5Widgets_LIBRARIES}
-                                                        ${Qt5DBus_LIBRARIES}
-                                                        ${Qt5TestLib_LIBRARIES}
-                                                        ${Qt5Widgets_PRIVATE_INCLUDE_DIRS}
-                                                        ${Qt5Core_PRIVATE_INCLUDE_DIRS}
-                                                        ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+target_include_directories(${PROJECT_NAME_TEST} PUBLIC
+                                                        ${Qt${QT_VERSION_MAJOR}Widgets_PRIVATE_INCLUDE_DIRS}
+                                                        ${Qt${QT_VERSION_MAJOR}Core_PRIVATE_INCLUDE_DIRS}
+                                                        ${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS}
                                                         ${PROJECT_BINARY_DIR}
                                                         ${DtkWidget_INCLUDE_DIRS}
-                                                        ${DtkCore_LIBRARIES}
-                                                        ${DtkGUI_INCLUDE_DIRS}
+                                                        ${DtkGui_INCLUDE_DIRS}
+                                                        ${DtkCore_INCLUDE_DIRS}
                                                         ${GOBJECT_INCLUDE_DIRS}
-                                                        ${LIBSECRET_INCLUDE_DIRS})
+                                                        ${LIBSECRET_INCLUDE_DIRS}
+                                                        ${chardet_INCLUDE_DIRS})
 
-target_link_libraries(${PROJECT_NAME_TEST} PUBLIC ${LINK_LIBS} Qt5::Test ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} -lpthread -lm)
+find_package(ICU COMPONENTS i18n uc REQUIRED)
+
+target_link_libraries(${PROJECT_NAME_TEST} PUBLIC ${LINK_LIBS} Qt${QT_VERSION_MAJOR}::Test ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} -lpthread -lm ICU::i18n ICU::uc chardet uchardet)
 
 #------------------------------ 创建'make test'指令---------------------------------------
 add_custom_target(test
@@ -155,4 +161,3 @@ if(CMAKE_SAFETYTEST STREQUAL "CMAKE_SAFETYTEST_ARG_ON")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=undefined,address -O2")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=undefined,address -O2")
 endif()
-

--- a/tests/src/customcommand/ut_customcommandoptdlg_test.cpp
+++ b/tests/src/customcommand/ut_customcommandoptdlg_test.cpp
@@ -144,7 +144,7 @@ TEST_F(UT_CustomCommandOptDlg_Test, slotAddSaveButtonClicked)
     EXPECT_TRUE(cmdDlg->m_nameLineEdit->text().isEmpty());
 
     //add-条件：name.length>MAX_NAME_LEN,cammand=""
-    cmdDlg->m_nameLineEdit->setText(QString('A', MAX_NAME_LEN + 1));
+    cmdDlg->m_nameLineEdit->setText(QString(MAX_NAME_LEN + 1, QChar('A')));
     cmdDlg->slotAddSaveButtonClicked();
     EXPECT_TRUE(cmdDlg->m_nameLineEdit->text().count() > 0);
 

--- a/tests/src/customcommand/ut_customcommandpanel_test.cpp
+++ b/tests/src/customcommand/ut_customcommandpanel_test.cpp
@@ -36,9 +36,11 @@ private:
     ShortcutManager *m_scManager;
 };
 
-static QAction m_action;
+static QAction *m_action = nullptr;
 static QAction *ut_m_pdlg_getCurCustomCmd() {
-    return &m_action;
+    if (!m_action)
+        m_action = new QAction();
+    return m_action;
 }
 
 UT_CustomCommandPanel_Test::UT_CustomCommandPanel_Test():m_scManager(nullptr)

--- a/tests/src/main/main.cpp
+++ b/tests/src/main/main.cpp
@@ -16,9 +16,11 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QT_BEGIN_NAMESPACE
 QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS
 QT_END_NAMESPACE
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -26,7 +28,9 @@ int main(int argc, char *argv[])
     TerminalApplication app(argc, argv);
 
     QTEST_DISABLE_KEYPAD_NAVIGATION
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QTEST_ADD_GPU_BLACKLIST_SUPPORT
+#endif
 
     testing::InitGoogleTest(&argc, argv);
     int ret = RUN_ALL_TESTS();

--- a/tests/src/main/ut_mainwindow_test.cpp
+++ b/tests/src/main/ut_mainwindow_test.cpp
@@ -22,7 +22,8 @@
 //Qt单元测试相关头文件
 #include <QTest>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
+#include <QEnterEvent>
 #include <QtConcurrent/QtConcurrent>
 #include <QKeyEvent>
 #include <QShortcut>
@@ -66,7 +67,8 @@ TEST_F(UT_SwitchThemeMenu_Test, SwitchThemeMenuTest)
     QKeyEvent keyPress(QEvent::KeyPress, Qt::Key_Up, Qt::NoModifier);
     m_themeMenu->keyPressEvent(&keyPress);
 
-    m_themeMenu->enterEvent(&e);
+    QEnterEvent enterEvent{QPointF(), QPointF(), QPointF()};
+    m_themeMenu->enterEvent(&enterEvent);
     EXPECT_EQ(m_themeMenu->hoveredThemeStr, "");
 
     QHideEvent he;
@@ -325,7 +327,7 @@ TEST_F(UT_MainWindow_Test, QuakeWindowTest)
 
     m_quakeWindow->show();
 
-    int desktopWidth = QApplication::desktop()->availableGeometry().width();
+    int desktopWidth = QGuiApplication::primaryScreen()->availableGeometry().width();
     EXPECT_EQ(m_quakeWindow->width(), desktopWidth);
     EXPECT_GE(m_quakeWindow->height(), 0);
 
@@ -1676,7 +1678,7 @@ TEST_F(UT_MainWindow_Test, slotWorkAreaResized)
 
     mainWindow->slotWorkAreaResized();
     //雷神窗口的宽度为桌面宽度
-    EXPECT_TRUE(QApplication::desktop()->availableGeometry().width() == mainWindow->width());
+    EXPECT_TRUE(QGuiApplication::primaryScreen()->availableGeometry().width() == mainWindow->width());
     mainWindow->deleteLater();
 }
 

--- a/tests/src/main/ut_service_test.cpp
+++ b/tests/src/main/ut_service_test.cpp
@@ -190,20 +190,20 @@ TEST_F(UT_Service_Test, initSetting)
 {
     DELETE_PTR(m_service->m_settingDialog);
     // 初始化设置框
-    m_service->initSetting();
+    m_service->initSetting(nullptr);
 
     DELETE_PTR(m_service->m_settingDialog);
     // 初始化设置框
     Stub stub;
     stub.set(ADDR(DWindowManagerHelper,hasComposite),ut_dtk_managerhelper_hasComposite);
-    m_service->initSetting();
+    m_service->initSetting(nullptr);
 
     // 判断设置框是否被初始化
     EXPECT_NE(m_service->m_settingDialog, nullptr);
     // 获取刚刚生成的dialog
     DSettingsDialog *settingDialog = m_service->m_settingDialog;
     // 再次初始化
-    m_service->initSetting();
+    m_service->initSetting(nullptr);
     // 若已经初始化过，此时指针不变
     EXPECT_NE(m_service->m_settingDialog, nullptr);
     EXPECT_EQ(m_service->m_settingDialog, settingDialog);
@@ -274,7 +274,7 @@ TEST_F(UT_Service_Test, isSettingDialogVisible2)
     EXPECT_EQ(m_service->isSettingDialogVisible(), false);
 
     // 初始化设置窗口，但是没有show此时应该得到false
-    m_service->initSetting();
+    m_service->initSetting(nullptr);
     EXPECT_EQ(m_service->isSettingDialogVisible(), false);
 
     // 此时显示设置框，应该得到true
@@ -365,7 +365,7 @@ TEST_F(UT_Service_Test, onDesktopWorkspaceSwitched)
 TEST_F(UT_Service_Test, slotWMChanged)
 {
     UT_STUB_QWIDGET_SETVISIBLE_CREATE;
-    m_service->slotWMChanged("deepin wm");
+    m_service->slotWMChanged();
     //会调用setvisible函数
     EXPECT_TRUE(UT_STUB_QWIDGET_SETVISIBLE_RESULT);
 }

--- a/tests/src/main/ut_terminalapplication_test.cpp
+++ b/tests/src/main/ut_terminalapplication_test.cpp
@@ -12,9 +12,10 @@
 #include <QObject>
 #include <QTest>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QtConcurrent/QtConcurrent>
 #include <QMainWindow>
+#include <QElapsedTimer>
 
 UT_TerminalApplication_Test::UT_TerminalApplication_Test()
 {
@@ -58,7 +59,7 @@ TEST_F(UT_TerminalApplication_Test, getsetStartTime)
         delete loop;
     });
 
-    QTime useTime;
+    QElapsedTimer useTime;
     useTime.start();
     qint64 startTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
 
@@ -99,7 +100,7 @@ TEST_F(UT_TerminalApplication_Test, notify)
         loop->exec();
     });
 
-    QTime useTime;
+    QElapsedTimer useTime;
     useTime.start();
     qint64 startTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
 

--- a/tests/src/main/ut_windowsmanager_test.cpp
+++ b/tests/src/main/ut_windowsmanager_test.cpp
@@ -14,7 +14,7 @@
 //Qt单元测试相关头文件
 #include <QTest>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QtConcurrent/QtConcurrent>
 #include <QDebug>
 

--- a/tests/src/remotemanage/ut_remotemanagementpanel_test.cpp
+++ b/tests/src/remotemanage/ut_remotemanagementpanel_test.cpp
@@ -57,14 +57,13 @@ void UT_RemoteManagementPanel_Test::prepareData()
     serverConfigManager->initServerConfig();
 
     int serverConfigCount = getServerConfigCount();
-    qDebug() << serverConfigCount << endl;
+    qDebug() << serverConfigCount << Qt::endl;
 
     QString groupName = QString("group_01");
 
-    qsrand(static_cast<uint>(time(nullptr)));
     ServerConfig *config = new ServerConfig();
     config->m_serverName = QString("new_server_%1").arg(Utils::getRandString());
-    config->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+    config->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     config->m_userName = QString("zhangsan");
     config->m_password = QString("123");
     config->m_privateKey = QString("");
@@ -84,10 +83,9 @@ void UT_RemoteManagementPanel_Test::prepareData()
     ServerConfig *currConfig = serverConfigManager->getServerConfig(config->m_serverName);
     EXPECT_NE(currConfig, nullptr);
 
-    qsrand(static_cast<uint>(time(nullptr)));
     ServerConfig *newConfig = new ServerConfig();
     newConfig->m_serverName = QString("new_server_%1").arg(Utils::getRandString());
-    newConfig->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+    newConfig->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     newConfig->m_userName = QString("uos");
     newConfig->m_password = QString("123456");
     newConfig->m_privateKey = QString("");
@@ -141,7 +139,7 @@ TEST_F(UT_RemoteManagementPanel_Test, setFocusInPanel)
 
     panel.setFocusInPanel();
     int listIndex = panel.getListIndex();
-    qDebug() << "listIndex:" << listIndex << endl;
+    qDebug() << "listIndex:" << listIndex << Qt::endl;
     EXPECT_EQ(listIndex, -1);
 
     // 最后一种情况
@@ -202,10 +200,10 @@ TEST_F(UT_RemoteManagementPanel_Test, clearListFocus)
     EXPECT_EQ(panel.size().height(), PANEL_HEIGHT);
 
     panel.clearListFocus();
-    EXPECT_EQ(panel.m_backButton->hasFocus(), false);
-    EXPECT_EQ(panel.m_listWidget->hasFocus(), false);
-    EXPECT_EQ(panel.m_searchEdit->hasFocus(), false);
-    EXPECT_EQ(panel.m_listWidget->currentIndex(), -1);
+    EXPECT_EQ(panel.m_backButton ? panel.m_backButton->hasFocus() : false, false);
+    EXPECT_EQ(panel.m_listWidget ? panel.m_listWidget->hasFocus() : false, false);
+    EXPECT_EQ(panel.m_searchEdit ? panel.m_searchEdit->hasFocus() : false, false);
+    EXPECT_EQ(panel.m_listWidget ? panel.m_listWidget->currentIndex() : -1, -1);
 }
 
 TEST_F(UT_RemoteManagementPanel_Test, refreshSearchState)

--- a/tests/src/remotemanage/ut_remotemanagementplugn_test.cpp
+++ b/tests/src/remotemanage/ut_remotemanagementplugn_test.cpp
@@ -120,10 +120,9 @@ TEST_F(UT_RemoteManagementPlugin_Test, createShellFile)
 
     QString groupName = QString("group_01");
 
-    qsrand(static_cast<uint>(time(nullptr)));
     ServerConfig *config = new ServerConfig();
     config->m_serverName = QString("new_server_%1").arg(Utils::getRandString());
-    config->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+    config->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     config->m_userName = QString("zhangsan");
     config->m_password = QString("123");
     config->m_privateKey = QString("");

--- a/tests/src/remotemanage/ut_serverconfigmanager_test.cpp
+++ b/tests/src/remotemanage/ut_serverconfigmanager_test.cpp
@@ -52,14 +52,13 @@ TEST_F(UT_ServerConfigManager_Test, ServerConfigManagerTest)
     serverConfigManager->initServerConfig();
 
     int serverConfigCount = getServerConfigCount();
-    qDebug() << serverConfigCount << endl;
+    qDebug() << serverConfigCount << Qt::endl;
 
     QString groupName = QString("group_01");
 
-    qsrand(static_cast<uint>(time(nullptr)));
     ServerConfig *config = new ServerConfig();
     config->m_serverName = QString("new_server_%1").arg(Utils::getRandString());
-    config->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+    config->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     config->m_userName = QString("zhangsan");
     config->m_password = QString("123");
     config->m_privateKey = QString("");
@@ -79,10 +78,9 @@ TEST_F(UT_ServerConfigManager_Test, ServerConfigManagerTest)
     ServerConfig *currConfig = serverConfigManager->getServerConfig(config->m_serverName);
 
     //替换conf
-    qsrand(static_cast<uint>(time(nullptr)));
     ServerConfig *newConfig = new ServerConfig();
     newConfig->m_serverName = QString("new_server_%1").arg(Utils::getRandString());
-    newConfig->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+    newConfig->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     newConfig->m_userName = QString("uos");
     newConfig->m_password = QString("123456");
     newConfig->m_privateKey = QString("");

--- a/tests/src/settings/ut_newdspinbox_test.cpp
+++ b/tests/src/settings/ut_newdspinbox_test.cpp
@@ -37,7 +37,7 @@ TEST_F(UT_NewDSpinBox_Test, WheelEvent_Increase)
     NewDspinBox *spinBox = new NewDspinBox;
     spinBox->setValue(20);
 
-    QWheelEvent event(QPointF(63, 29), 120, Qt::NoButton, Qt::NoModifier);
+    QWheelEvent event(QPointF(63, 29), QPointF(63, 29), QPoint(0, 120), QPoint(0, 120), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
     QApplication::sendEvent(spinBox, &event);
 
     EXPECT_TRUE(spinBox->value() == 21);
@@ -50,7 +50,7 @@ TEST_F(UT_NewDSpinBox_Test, WheelEvent_Reduce)
     NewDspinBox *spinBox = new NewDspinBox;
     spinBox->setValue(20);
 
-    QWheelEvent event(QPointF(63, 29), -120, Qt::NoButton, Qt::NoModifier);
+    QWheelEvent event(QPointF(63, 29), QPointF(63, 29), QPoint(0, -120), QPoint(0, -120), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
     QApplication::sendEvent(spinBox, &event);
     EXPECT_TRUE(spinBox->value() == 19);
     spinBox->deleteLater();

--- a/tests/src/views/ut_focusframe_test.cpp
+++ b/tests/src/views/ut_focusframe_test.cpp
@@ -45,7 +45,7 @@ TEST_F(UT_FocusFrame_Test, enterEvent)
 {
     FocusFrame frame;
     frame.resize(50, 50);
-    QEvent *event = new QEvent(QEvent::Enter);
+    QEnterEvent *event = new QEnterEvent(QPointF(), QPointF(), QPointF());
     frame.enterEvent(event);
     delete event;
 

--- a/tests/src/views/ut_itemwidget_test.cpp
+++ b/tests/src/views/ut_itemwidget_test.cpp
@@ -344,14 +344,15 @@ TEST_F(UT_ItemWidget_Test, onFocusOut)
 
 TEST_F(UT_ItemWidget_Test, enterEvent)
 {
-    QEvent e(QEvent::None);
     ItemWidget w(ItemFuncType::ItemFuncType_Item, nullptr);
 
     UT_STUB_QWIDGET_SHOW_CREATE;
-    w.enterEvent(&e);
+    QEnterEvent enterEvent{QPointF(), QPointF(), QPointF()};
+    w.enterEvent(&enterEvent);
     EXPECT_TRUE(UT_STUB_QWIDGET_SHOW_RESULT);
 
-    w.leaveEvent(&e);
+    QEvent leaveEv(QEvent::None);
+    w.leaveEvent(&leaveEv);
     EXPECT_TRUE(ItemFuncType::ItemFuncType_Item == w.m_functType);
 
     QSignalSpy signalpy(&w, &ItemWidget::focusOut);

--- a/tests/src/views/ut_listview_test.cpp
+++ b/tests/src/views/ut_listview_test.cpp
@@ -106,7 +106,7 @@ TEST_F(UT_ListView_Test, onRemoteItemModify)
 
         ServerConfig *config = new ServerConfig();
         config->m_serverName = QString("server_%1").arg(i);
-        config->m_address = QString("192.168.10.%1").arg(qrand() % 255);
+        config->m_address = QString("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
         config->m_userName = QString("%1").arg(Utils::getRandString());
         config->m_password = QString("123");
         config->m_privateKey = QString("");
@@ -245,7 +245,7 @@ ServerConfig* generateNewServerConfig()
 {
     ServerConfig *config = new ServerConfig();
     config->m_serverName = QStringLiteral("new_server_listview_test");
-    config->m_address = QStringLiteral("192.168.10.%1").arg(qrand() % 255);
+    config->m_address = QStringLiteral("192.168.10.%1").arg(QRandomGenerator::global()->bounded(255));
     config->m_userName = QStringLiteral("server_user");
     config->m_password = QStringLiteral("123456");
     config->m_privateKey = QStringLiteral("");

--- a/tests/src/views/ut_tabbar_test.cpp
+++ b/tests/src/views/ut_tabbar_test.cpp
@@ -433,7 +433,7 @@ TEST_F(UT_Tabbar_Test, handleDragActionChanged)
 
     Stub stub;
     stub.set(ADDR(DTabBar, dragIconWindow), ut_tablbar_dragIconWindow);
-    stub.set(ADDR(QWindow, setProperty), ut_window_setProperty);
+    stub.set((bool (QWindow::*)(const char *, const QVariant &))ADDR(QWindow, setProperty), ut_window_setProperty);
 
     qApp->setOverrideCursor(Qt::CrossCursor);
     tabbar.handleDragActionChanged(Qt::IgnoreAction);
@@ -450,7 +450,7 @@ TEST_F(UT_Tabbar_Test, handleMiddleButtonClick)
     TabBar *tabbar = new TabBar(w);
     tabbar->addTab(generateUniqueId(), "tab01");
     QSignalSpy spy(tabbar, &DTabBar::tabCloseRequested);
-    QMouseEvent mouseEvent(QEvent::MouseButtonRelease, tabbar->tabRect(0).center(), Qt::MidButton, Qt::NoButton, Qt::NoModifier);
+    QMouseEvent mouseEvent(QEvent::MouseButtonRelease, tabbar->tabRect(0).center(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
     tabbar->handleMiddleButtonClick(&mouseEvent);
     qDebug() << spy.count();
     EXPECT_TRUE(1 == spy.count());

--- a/tests/src/views/ut_termwidget_test.cpp
+++ b/tests/src/views/ut_termwidget_test.cpp
@@ -303,7 +303,7 @@ TEST_F(UT_TermWidget_Test, wheelEvent)
 
     TermWidget *termWidget = currTermPage->m_currentTerm;
 
-    QWheelEvent event(QPointF(QPoint(0,0)),QPointF(QPoint(0,0)),0,0,0,Qt::Horizontal);
+    QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
     QCoreApplication::sendEvent(termWidget,&event);
 }
 


### PR DESCRIPTION
Update CMake build system and test source code to support both Qt5 and Qt6, including API replacements and event signature changes.

更新CMake构建系统和测试源码以同时支持Qt5和Qt6，包含API替换
和事件签名变更。

Log: 单元测试适配Qt5/Qt6双版本兼容
Influence: 单元测试构建系统与源码兼容Qt5和Qt6，涉及API替换、事件签名变更和条件编译，确保双版本下均可正常编译运行。