### PR TITLE
fix: Built-in themes do not take effect immediately

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -119,6 +119,14 @@ void SwitchThemeMenu::enterEvent(EnterEvent *event)
     // qCDebug(mainprocess) << "Enter SwitchThemeMenu::enterEvent";
     hoveredThemeStr = "";
     return QMenu::enterEvent(event);
+}
+
+void SwitchThemeMenu::showEvent(QShowEvent *event)
+{
+    // 子菜单显示 = 进入 hover 预览周期：复位闸门，使 themeActionHoveredSlot 能放行后续 hover。
+    // 点击主题项时 themeActionTriggeredSlot 会重置为 true，避免菜单关闭尾随 hover 覆盖真实选择。
+    Settings::instance()->bSwitchTheme = false;
+    QMenu::showEvent(event);
 }
 
 void SwitchThemeMenu::keyPressEvent(QKeyEvent *event)

--- a/src/main/mainwindow.h
+++ b/src/main/mainwindow.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -84,6 +84,11 @@ public:
      * @param event 键盘主题项左键按下离开事件
      */
     void keyPressEvent(QKeyEvent *event) override;
+    /**
+     * @brief 主题菜单显示时触发，复位 hover 预览闸门
+     * @param event 显示事件
+     */
+    void showEvent(QShowEvent *event) override;
 
 signals:
     //主题项在鼠标停靠离开时触发的信号


### PR DESCRIPTION
log: Since both the initial value and the value after clicking are true, the hover state always returns directly at the gate and never reaches the branch where it is set to false. Result: When entering the theme submenu for the first time, hover previews for all built-in themes fail to trigger.

pms: bug-365281