### PR TITLE
fix: Prevent terminal theme from being changed by other applications

### DIFF
--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+﻿// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -148,6 +148,23 @@ void Settings::init()
         if (colorScheme() != sysTheme) {
             qCDebug(tsettings) << "Syncing colorScheme to system theme:" << colorScheme() << "->" << sysTheme;
             setColorScheme(sysTheme);
+        }
+    }
+
+    // 按 colorScheme 对齐 paletteType，激活 dtkgui 的 isCustomPalette() 过滤，
+    // 避免外部应用切主题时 dde-appearance 经 DPlatformTheme 把 palette 推送到本进程 qApp。
+    // 跟随系统模式（extendColorScheme 为空且 paletteType 为 UnknownType）保持原状。
+    {
+        auto helper = DGuiApplicationHelper::instance();
+        const bool isFollowSystem = extendColorScheme().isEmpty()
+                                    && helper->paletteType() == DGuiApplicationHelper::UnknownType;
+        if (!isFollowSystem) {
+            const auto desiredType = (colorScheme() == "Light")
+                                     ? DGuiApplicationHelper::LightType
+                                     : DGuiApplicationHelper::DarkType;
+            if (helper->paletteType() != desiredType) {
+                helper->setPaletteType(desiredType);
+            }
         }
     }
     /******** Modify by n014361 wangpeili 2020-01-10:   增加窗口状态选项  ************/


### PR DESCRIPTION
log: When the terminal is in fixed Light/Dark mode but dtkgui's per-app DConfig (org.deepin.dtk.preference.themeType) is out of sync with the saved colorScheme (e.g. upgrades from older builds, wiped or imported DConfig, shipped conf already containing a fixed theme), the isCustomPalette() guard in DGuiApplicationHelper never engages and external dde-appearance palette broadcasts propagate to qApp. Align dtkgui's paletteType with the saved colorScheme at the end of Settings::init() so the existing guard takes effect. Follow-system mode (extendColorScheme empty AND paletteType==UnknownType) is preserved.

pms: bug-365877