### PR TITLE
fix: show input method on mouse release when terminal has focus

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -33,6 +33,7 @@
 #include <QTime>
 #include <QFile>
 #include <QGridLayout>
+#include <QInputMethod>
 #include <QLabel>
 #include <QLayout>
 #include <QPainter>
@@ -2593,6 +2594,9 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
                         charLine + 1 +_scrollBar->value() -_scrollBar->maximum() , 2);
     }
     dragInfo.state = diNone;
+    if (hasFocus()) {
+        qApp->inputMethod()->show();
+    }
   }
 
   bool midClick = (ev->button() == MID_BTN);


### PR DESCRIPTION
Explicitly call inputMethod()->show() after mouse release to ensure the IME panel appears for text entry in the terminal widget.

在终端窗口拥有焦点时，鼠标释放后显式调用 inputMethod()->show()，
确保输入法面板能够正常弹出。

Log: 鼠标释放后显示输入法
Influence: 终端在获得焦点并点击鼠标后能正常唤起输入法，改善中文等输入法的使用体验。

## Summary by Sourcery

Bug Fixes:
- Fix missing IME panel display after mouse release when the terminal display has focus to improve input method usability.