### PR TITLE
fix(terminal): skip wide char placeholders when copying text

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalCharacterDecoder.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalCharacterDecoder.cpp
@@ -107,7 +107,9 @@ void PlainTextDecoder::decodeLine(const Character* const characters, int count, 
 
     for (int i=0;i<outputCount;)
     {
-        plainText.push_back( characters[i].character );
+        if (characters[i].character != 0) {
+            plainText.push_back(characters[i].character);
+        }
         i += qMax(1,Character::width(characters[i].character));
     }
     *_output << QString::fromStdWString(plainText);


### PR DESCRIPTION
Skip zero-width placeholder cells used by wide characters in plain text decoding.

Log: Fix invisible characters in copied selection

PMS: BUG-367885