### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/deepin-terminal.desktop
+++ b/src/deepin-terminal.desktop
@@ -219,9 +219,9 @@ Name[ug]=Deepin تېرمىنالى
 Name[uk]=Термінал Deepin
 Name[vi]=Deepin Terminal
 Name[lo]=ເທີມິນັນ
-Name[zh_CN]=深度终端
-Name[zh_HK]=Deepin 終端
-Name[zh_TW]=Deepin 終端機
+Name[zh_CN]=终端
+Name[zh_HK]=終端
+Name[zh_TW]=終端機
 
 [NewWindow Shortcut Group]
 Exec=deepin-terminal


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Ensure zh_CN, zh_HK, and zh_TW Name/Comment fields in the terminal desktop file no longer include redundant "深度"/"deepin" prefixes.