### PR TITLE
fix(terminal): Ctrl+Click does not open URLs ending with a port number

### DIFF
--- a/3rdparty/terminalwidget/lib/Filter.cpp
+++ b/3rdparty/terminalwidget/lib/Filter.cpp
@@ -523,8 +523,11 @@ void UrlFilter::HotSpot::activate(const QString &actionName)
 /** modify begin by ut001121 zhangmeng 20201215 for 1040-4 Ctrl键+鼠标点击超链接打开网页 */
 /** del
 const QRegularExpression UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]"));*/
+// port boundary: (?![0-9]) must stay a non-consuming lookahead. Replacing it
+// with [^0-9] swallows the boundary char (newline/space/'/') into the URL and
+// QUrl::StrictMode rejects it, so Ctrl+Click on "http://host:port" silently fails.
 const QRegularExpression UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[\\w.@-]+"
-                                                     "([:]((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([1-9][0-9]{3})|([1-9][0-9]{2})|([1-9][0-9])|([0-9]))[^0-9])?"
+                                                     "([:]((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([1-9][0-9]{3})|([1-9][0-9]{2})|([1-9][0-9])|([0-9]))(?![0-9]))?"
                                                      "([/][\\w.@?^=%&/~+#-]+)?"));
 /** modify end by ut001121 */
 


### PR DESCRIPTION
## Problem

In deepin-terminal, **Ctrl + Left-click** silently fails to open a URL when the URL ends with a port number and no trailing path/slash:

| URL | Hover underline | Ctrl+Click opens? |
|---|---|---|
| `http://localhost:8000`      | ✅ shown | ❌ **does nothing** |
| `http://localhost:8000/`     | ✅ shown | ✅ works |
| `http://www.baidu.com:4443/` | ✅ shown | ✅ works |
| `http://localhost:8000/path` | ✅ shown | ⚠️ opens but truncated to `http://localhost:8000/` |

So the user sees a working underline on `http://localhost:8000`, clicks it, and nothing happens — confusing and looks broken.

## Root Cause

`UrlFilter::FullUrlRegExp` in `3rdparty/terminalwidget/lib/Filter.cpp` validates the port number with a **consuming** boundary check, `[^0-9]`:

```cpp
// before
"([:]((6553[0-5])|...|([0-9]))[^0-9])?"
//                                   ^^^^^ consuming: eats the next char into the URL
```

`[^0-9]` matches and **consumes** the first character after the port (the newline at end of line, a space, or a `/`). That character becomes part of the captured URL string. For `http://localhost:8000` printed on its own line, the capture is `http://localhost:8000\n`.

`UrlFilter::HotSpot::activate()` then hands the string to `QUrl(url, QUrl::StrictMode)`, which **rejects** any URL containing a control character like `\n`. The open action is dropped silently — no error, no browser.

The trailing-slash case `http://localhost:8000/` happens to work because the consumed `/` still leaves a syntactically valid URL.

The same consumed `/` also explains the truncation in the last row: the optional path group `([/][\w.@?^=%&/~+#-]+)?` can no longer match because the leading `/` was already eaten by `[^0-9]`.

## Fix

Replace the consuming character class `[^0-9]` with a **non-consuming negative lookahead** `(?![0-9])`:

```cpp
// after
"([:]((6553[0-5])|...|([0-9]))(?![0-9]))?"
//                                   ^^^^^^^^ zero-width: asserts, does not consume
```

The lookahead asserts the port is not followed by another digit (so `80000` is still rejected as an out-of-range port) **without** swallowing the boundary character. The captured URL stays clean and `QUrl::StrictMode` accepts it. As a side effect, the trailing-path case also stops being truncated because the `/` is left available for the path group.

## Verification

Tested with a Python equivalent of the regex (PCRE2-compatible, which is what `QRegularExpression` uses):

| Input (buffer) | Before (captured) | After (captured) |
|---|---|---|
| `echo http://localhost:8000\n` (the bug) | `http://localhost:8000\n` ❌ | `http://localhost:8000` ✅ |
| `echo http://localhost:8000/ \n`        | `http://localhost:8000/`      | `http://localhost:8000` ✅ |
| `echo http://localhost:8000/path\n`    | `http://localhost:8000/` ❌ truncated | `http://localhost:8000/path` ✅ |
| `echo http://www.baidu.com:4443/\n`    | `http://www.baidu.com:4443/`  | `http://www.baidu.com:4443` ✅ |
| `echo http://localhost:80000\n` (invalid port) | `http://localhost` (boundary still rejects) | `http://localhost` (boundary still rejects) ✅ |

Invalid-port handling (`80000`, out-of-range 0–65535) is preserved — the lookahead still fails to match and the port group is dropped, identical to the previous behavior.

## Scope of Change

A single one-character-class replacement in `3rdparty/terminalwidget/lib/Filter.cpp`. No behavior change for valid URLs without ports, for email addresses, or for invalid port numbers.

## How to Reproduce

1. `echo http://localhost:8000` in deepin-terminal
2. Hover the URL — underline appears
3. Ctrl + Left-click — nothing opens (bug)
4. Compare with `echo http://localhost:8000/` — Ctrl+Click opens the browser

After this patch, step 3 opens the browser as expected.
