### PR TITLE
feat: add entries for newest xdg-terminal-exec spec

### DIFF
--- a/src/deepin-terminal.desktop
+++ b/src/deepin-terminal.desktop
@@ -13,6 +13,8 @@ X-Deepin-Vendor=deepin
 X-Deepin-Singleton=true
 Actions=new-window;quake-mode;
 MimeType=x-scheme-handler/dsg-terminal-exec
+X-TerminalArgExec=-e
+X-TerminalArgDir=-w
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
See also:

- https://gitlab.freedesktop.org/terminal-wg/specifications/-/merge_requests/3
- https://github.com/orgs/linuxdeepin/discussions/9817

## Summary by Sourcery

New Features:
- Add support for the newest xdg-terminal-exec specification in the deepin-terminal desktop entry.