### PR TITLE
fix: use QScreen API for half-screen size to fix split-screen on Wayland

### DIFF
--- a/src/main/mainwindow.cpp
+++ b/src/main/mainwindow.cpp
@@ -976,8 +976,15 @@ QString MainWindow::getConfigWindowState()
 
 QSize MainWindow::halfScreenSize()
 {
-    int w = qApp->desktop()->availableGeometry().width();
-    int h = qApp->desktop()->availableGeometry().height();
+    qCDebug(mainprocess) << "Enter MainWindow::halfScreenSize";
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen) {
+        qCritical() << "Can't get the screen where the cursor is located!";
+        return QSize(0, 0);
+    }
+
+    int w = screen->availableGeometry().width();
+    int h = screen->availableGeometry().height();
 
     QSize size;
     //开启窗管特效时会有1px的border


### PR DESCRIPTION
## 根因分析

**强根因**：终端设置"启动时窗口=分屏"在 1070/Wayland（treeland）下实际未分屏。

`NormalWindow::initWindowAttribute()` 的 split_screen 分支（`src/main/mainwindow.cpp:2634-2636`）执行 `resize(halfScreenSize())`，而 `halfScreenSize()`（`src/main/mainwindow.cpp:977-989`）使用已废弃的 `qApp->desktop()->availableGeometry()`（`QDesktopWidget`）。该 API 在 Wayland 下不能稳定返回目标屏可用几何，导致 resize 拿到错误/退化尺寸 → 窗口非半屏。

唯独分屏失效的原因：`window_maximum`/`fullscreen` 走 Qt 窗口状态协议（Wayland 生效），`window_normal` 用 wininfo-config 保存尺寸——都不依赖运行时屏幕几何 API；唯独 `split_screen` 的目标尺寸完全依赖 `halfScreenSize()` 这个未做 Wayland 适配的废弃 API。

版本线核对：master commit `57b7c437`（Wang Yu，2026-03-02，明确 treeland/Wayland）已修复同一函数，但**未回移 release/eagle**（`git tag --contains 57b7c437` → 6.5.29+；`5.9.47..5.9.51` 均不含）。本 PR 即将该修复回移到 release/eagle。

## 修复方案

将 `halfScreenSize()` 由 `qApp->desktop()->availableGeometry()` 迁移为 `QGuiApplication::screenAt(QCursor::pos())->availableGeometry()` + 空指针保护，对齐 master `57b7c437`：
- 取"光标所在屏"的可用几何（Wayland 安全的 `QScreen` API）；
- `screenAt()` 返回 `nullptr` 时记 `qCritical` 日志并返回 `QSize(0,0)`（被最小尺寸夹取，不崩溃）；
- 保留 `hasComposite()` 的 1px border 逻辑（bug#87042 修复产物，不撤销）。

改动范围：`src/main/mainwindow.cpp` `halfScreenSize()`，9 行增 2 行删，函数签名不变。

## 改动安全评估

**低风险**。函数签名 `QSize halfScreenSize()` 不变；2 处调用者均在 `MainWindow` 内部（split_screen 的 `resize`、`saveWindowSize` 的尺寸比较），迁移后行为改善无破坏。blame 显示几何行源自 bug#87042 修复，本次保留其 border 逻辑，不引入回归。空指针路径有 `qCritical` 诊断日志（顺带回应复核保留意见）。

## 测试建议

项目存在已有测试 `tests/src/main/ut_mainwindow_test.cpp`，建议自行运行验证（本次按规范未新增/运行测试）。

## Summary by Sourcery

Update window half-screen sizing to use cursor-targeted QScreen geometry instead of deprecated desktop geometry APIs, ensuring correct split-screen behavior on Wayland.

Bug Fixes:
- Fix split-screen window sizing on Wayland by basing half-screen size on the active screen's available geometry and handling missing screen info safely.

Enhancements:
- Add debug and critical logging around half-screen size calculation to aid diagnosing screen detection issues.