### PR TITLE
fix(terminalwidget): allow terminal apps to handle Shift+Tab

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -2797,10 +2797,16 @@ void TerminalDisplay::mouseTripleClickEvent(QMouseEvent* ev)
 
 bool TerminalDisplay::focusNextPrevChild( bool next )
 {
-  if (next)
-    return false; // This disables changing the active part in konqueror
-                  // when pressing Tab
-  return QWidget::focusNextPrevChild( next );
+  // 原实现中，Tab 会留给终端处理；Shift+Tab 则会调用
+  // QWidget::focusNextPrevChild(false)，导致焦点从终端切换到标题栏控件。
+  // 为了让 Claude Code 等终端程序能够处理 Shift+Tab，屏蔽原有焦点切换逻辑。
+  // if (next)
+  //   return false; // This disables changing the active part in konqueror
+  //                 // when pressing Tab
+  // return QWidget::focusNextPrevChild( next );
+
+  Q_UNUSED(next)
+  return false;
 }
 
 

--- a/tests/src/views/ut_termwidget_test.cpp
+++ b/tests/src/views/ut_termwidget_test.cpp
@@ -47,7 +47,43 @@ bool ut_contains()
     return true;
 }
 
+class TestTerminalDisplay : public Konsole::TerminalDisplay
+{
+public:
+    explicit TestTerminalDisplay(QWidget *parent = nullptr)
+        : Konsole::TerminalDisplay(parent)
+    {
+    }
+
+    using Konsole::TerminalDisplay::focusNextPrevChild;
+};
+
 #ifdef UT_TERMWIDGET_TEST
+TEST_F(UT_TermWidget_Test, focusNextPrevChild)
+{
+    QWidget window;
+    QWidget previousWidget(&window);
+    TestTerminalDisplay terminalDisplay(&window);
+
+    window.resize(400, 300);
+    previousWidget.setGeometry(0, 0, 100, 30);
+    terminalDisplay.setGeometry(0, 40, 400, 260);
+    previousWidget.setFocusPolicy(Qt::StrongFocus);
+    terminalDisplay.setFocusPolicy(Qt::StrongFocus);
+    QWidget::setTabOrder(&previousWidget, &terminalDisplay);
+
+    window.show();
+    window.activateWindow();
+    terminalDisplay.setFocus(Qt::OtherFocusReason);
+    QApplication::processEvents();
+
+    ASSERT_TRUE(terminalDisplay.hasFocus());
+    EXPECT_FALSE(terminalDisplay.focusNextPrevChild(true));
+    EXPECT_TRUE(terminalDisplay.hasFocus());
+    EXPECT_FALSE(terminalDisplay.focusNextPrevChild(false));
+    EXPECT_TRUE(terminalDisplay.hasFocus());
+}
+
 TEST_F(UT_TermWidget_Test, TermWidgetTest)
 {
     m_normalWindow->resize(800, 600);


### PR DESCRIPTION
Prevent QWidget focus traversal from consuming Shift+Tab in TerminalDisplay.

阻止 QWidget 焦点遍历在 TerminalDisplay 中消费 Shift+Tab。

Add a regression test for forward and backward focus traversal.

增加正向和反向焦点遍历的回归测试。

Log: 修复终端内无法使用Shift+Tab的问题
Bug: https://pms.uniontech.com/bug-view-374971.html
Issue: Fixes linuxdeepin/developer-center#3878
Influence: Shift+Tab交由终端程序处理，Win+Tab及标题栏键盘导航不变。

## Summary by Sourcery

Keep keyboard focus within the terminal display so terminal applications can handle Shift+Tab while preserving existing window navigation behavior.

Bug Fixes:
- Allow TerminalDisplay to pass both Tab and Shift+Tab through to terminal applications instead of triggering QWidget focus traversal.

Tests:
- Add regression coverage verifying that forward and backward focus traversal do not move focus away from the terminal display.