### PR TITLE
fix(terminalwidget): allow terminal apps to handle Shift+Tab

### DIFF
--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -2797,10 +2797,16 @@ void TerminalDisplay::mouseTripleClickEvent(QMouseEvent* ev)
 
 bool TerminalDisplay::focusNextPrevChild( bool next )
 {
-  if (next)
-    return false; // This disables changing the active part in konqueror
-                  // when pressing Tab
-  return QWidget::focusNextPrevChild( next );
+  // 原实现中，Tab 会留给终端处理；Shift+Tab 则会调用
+  // QWidget::focusNextPrevChild(false)，导致焦点从终端切换到标题栏控件。
+  // 为了让依赖 Shift+Tab 的终端程序能够正常接收该按键，屏蔽原有焦点切换逻辑。
+  // if (next)
+  //   return false; // This disables changing the active part in konqueror
+  //                 // when pressing Tab
+  // return QWidget::focusNextPrevChild( next );
+
+  Q_UNUSED(next)
+  return false;
 }
 
 

--- a/tests/src/views/ut_termwidget_test.cpp
+++ b/tests/src/views/ut_termwidget_test.cpp
@@ -48,6 +48,42 @@ bool ut_contains()
 }
 
 #ifdef UT_TERMWIDGET_TEST
+class TestTerminalDisplay : public Konsole::TerminalDisplay
+{
+public:
+    explicit TestTerminalDisplay(QWidget *parent = nullptr)
+        : Konsole::TerminalDisplay(parent)
+    {
+    }
+
+    using Konsole::TerminalDisplay::focusNextPrevChild;
+};
+
+TEST_F(UT_TermWidget_Test, focusNextPrevChild)
+{
+    QWidget window;
+    QWidget previousWidget(&window);
+    TestTerminalDisplay terminalDisplay(&window);
+
+    window.resize(400, 300);
+    previousWidget.setGeometry(0, 0, 100, 30);
+    terminalDisplay.setGeometry(0, 40, 400, 260);
+    previousWidget.setFocusPolicy(Qt::StrongFocus);
+    terminalDisplay.setFocusPolicy(Qt::StrongFocus);
+    QWidget::setTabOrder(&previousWidget, &terminalDisplay);
+
+    window.show();
+    window.activateWindow();
+    terminalDisplay.setFocus(Qt::OtherFocusReason);
+    QApplication::processEvents();
+
+    ASSERT_TRUE(terminalDisplay.hasFocus());
+    EXPECT_FALSE(terminalDisplay.focusNextPrevChild(true));
+    EXPECT_TRUE(terminalDisplay.hasFocus());
+    EXPECT_FALSE(terminalDisplay.focusNextPrevChild(false));
+    EXPECT_TRUE(terminalDisplay.hasFocus());
+}
+
 TEST_F(UT_TermWidget_Test, TermWidgetTest)
 {
     m_normalWindow->resize(800, 600);


### PR DESCRIPTION
## Summary

- Keep Shift+Tab available to applications running inside the terminal.
- Preserve Win+Tab and title-bar keyboard navigation.
- Add regression coverage for forward and backward focus traversal.

## Changes

| File | Change |
| --- | --- |
| `3rdparty/terminalwidget/lib/TerminalDisplay.cpp` | Prevent QWidget focus traversal from consuming Shift+Tab. |
| `tests/src/views/ut_termwidget_test.cpp` | Verify both focus traversal directions remain in the terminal. |

## Test Plan

- [x] Build `terminalwidget5`.
- [x] Build `deepin-terminal`.
- [x] Verify Shift+Tab remains in TerminalDisplay.

Bug: https://pms.uniontech.com/bug-view-374971.html

Issue: linuxdeepin/developer-center#3878

Replaces #566.

## Summary by Sourcery

Prevent terminal focus traversal from consuming keyboard navigation used by terminal applications while preserving surrounding UI navigation.

Bug Fixes:
- Keep Shift+Tab available to applications running inside the terminal instead of allowing it to move focus to surrounding widgets.

Enhancements:
- Preserve focus within the terminal display for both forward and backward focus traversal requests.

Tests:
- Add regression coverage confirming the terminal retains focus for both traversal directions.